### PR TITLE
forward support for other types of devices (non-PCI) plus relevant cleanup

### DIFF
--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -1133,8 +1133,9 @@ pci_config_setup(lm_ctx_t *lm_ctx, const lm_dev_info_t *dev_info)
     }
 
     // Initialise capabilities.
-    if (dev_info->nr_caps > 0) {
-        lm_ctx->caps = caps_create(dev_info->caps, dev_info->nr_caps);
+    if (dev_info->pci_info.nr_caps > 0) {
+        lm_ctx->caps = caps_create(dev_info->pci_info.caps,
+                                   dev_info->pci_info.nr_caps);
         if (lm_ctx->caps == NULL) {
             lm_log(lm_ctx, LM_ERR, "failed to create PCI capabilities: %m\n");
             goto err;

--- a/lib/libmuser.c
+++ b/lib/libmuser.c
@@ -1167,6 +1167,11 @@ lm_ctx_create(const lm_dev_info_t *dev_info)
         return NULL;
     }
 
+    if (dev_info->dev_type != LM_DEV_TYPE_PCI) {
+        errno = EINVAL;
+        return NULL;
+    }
+
     /*
      * FIXME need to check that the number of MSI and MSI-X IRQs are valid
      * (1, 2, 4, 8, 16 or 32 for MSI and up to 2048 for MSI-X).

--- a/lib/muser.h
+++ b/lib/muser.h
@@ -249,6 +249,13 @@ typedef struct {
 
 #define LM_MAX_CAPS (PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF) / PCI_CAP_SIZEOF
 
+/*
+ * Supported device types. Only PCI for now.
+ */
+typedef enum {
+    LM_DEV_TYPE_PCI
+} lm_dev_type_t;
+
 /**
  * Device information structure, used to create the lm_ctx.
  * To be filled and passed to lm_ctx_create()
@@ -275,6 +282,11 @@ typedef struct {
      * Log level. Messages above this level are not logged. Optional
      */
     lm_log_lvl_t    log_lvl;
+
+    /*
+     * Device type.
+     */
+    lm_dev_type_t   dev_type;
 
     /*
      * PCI configuration.

--- a/lib/muser.h
+++ b/lib/muser.h
@@ -165,51 +165,6 @@ enum {
     LM_DEV_NUM_REGS = 9
 };
 
-typedef struct {
-    uint32_t            irq_count[LM_DEV_NUM_IRQS];
-
-    /*
-     * Per-region information. Only supported regions need to be defined,
-     * unsupported regions should be left to 0.
-     */
-    lm_reg_info_t       reg_info[LM_DEV_NUM_REGS];
-
-    /*
-     * Device and vendor ID.
-     */
-    lm_pci_hdr_id_t     id;
-
-    /*
-     * Subsystem vendor and device ID.
-     */
-    lm_pci_hdr_ss_t     ss;
-
-    /*
-     * Class code.
-     */
-    lm_pci_hdr_cc_t     cc;
-} lm_pci_info_t;
-
-/*
- * Returns a pointer to the non-standard part of the PCI configuration space.
- */
-lm_pci_config_space_t *lm_get_pci_config_space(lm_ctx_t *lm_ctx);
-
-#define LM_DMA_REGIONS  0x10
-
-typedef enum {
-    LM_ERR,
-    LM_INF,
-    LM_DBG
-} lm_log_lvl_t;
-
-/**
- * Callback function signature for log function
- *
- * @lm_log_fn_t: typedef for log function.
- */
-typedef void (lm_log_fn_t) (void *pvt, const char *msg);
-
 /**
  * Callback function that gets called when a capability is accessed. The
  * callback is not called when the ID and next fields are accessed, these are
@@ -248,6 +203,64 @@ typedef struct {
 } lm_cap_t;
 
 #define LM_MAX_CAPS (PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF) / PCI_CAP_SIZEOF
+
+typedef struct {
+    uint32_t            irq_count[LM_DEV_NUM_IRQS];
+
+    /*
+     * Per-region information. Only supported regions need to be defined,
+     * unsupported regions should be left to 0.
+     */
+    lm_reg_info_t       reg_info[LM_DEV_NUM_REGS];
+
+    /*
+     * Device and vendor ID.
+     */
+    lm_pci_hdr_id_t     id;
+
+    /*
+     * Subsystem vendor and device ID.
+     */
+    lm_pci_hdr_ss_t     ss;
+
+    /*
+     * Class code.
+     */
+    lm_pci_hdr_cc_t     cc;
+
+    /*
+     * PCI capabilities. The user needs to only define the ID and size of each
+     * capability. The actual capability is not maintained by libmuser. When a
+     * capability is accessed the appropriate callback function is called.
+     */
+    lm_cap_t        caps[LM_MAX_CAPS];
+
+    /*
+     * Number of capabilities in above array.
+     */
+    int             nr_caps;
+
+} lm_pci_info_t;
+
+/*
+ * Returns a pointer to the non-standard part of the PCI configuration space.
+ */
+lm_pci_config_space_t *lm_get_pci_config_space(lm_ctx_t *lm_ctx);
+
+#define LM_DMA_REGIONS  0x10
+
+typedef enum {
+    LM_ERR,
+    LM_INF,
+    LM_DBG
+} lm_log_lvl_t;
+
+/**
+ * Callback function signature for log function
+ *
+ * @lm_log_fn_t: typedef for log function.
+ */
+typedef void (lm_log_fn_t) (void *pvt, const char *msg);
 
 /*
  * Supported device types. Only PCI for now.
@@ -293,17 +306,6 @@ typedef struct {
      */
     int (*reset)    (void *pvt);
 
-    /*
-     * PCI capabilities. The user needs to only define the ID and size of each
-     * capability. The actual capability is not maintained by libmuser. When a
-     * capability is accessed the appropriate callback function is called.
-     */
-    lm_cap_t        caps[LM_MAX_CAPS];
-
-    /*
-     * Number of capabilities in above array.
-     */
-    int             nr_caps;
 } lm_dev_info_t;
 
 /**

--- a/lib/muser.h
+++ b/lib/muser.h
@@ -269,11 +269,6 @@ typedef struct {
     void            *pvt;
 
     /*
-     * Whether an extended PCI configuration space should be created.
-     */
-    bool            extended;
-
-    /*
      * Function to call for logging. Optional.
      */
     lm_log_fn_t     *log;

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -52,6 +52,7 @@ bar2_access(void *pvt, char * const buf, size_t count, loff_t offset,
 int main(int argc, char **argv)
 {
     lm_dev_info_t dev_info = {
+        .dev_type = LM_DEV_TYPE_PCI,
         .pci_info = {
             .id = {.vid = 0x494F, .did = 0x0DC8 },
             .reg_info[LM_DEV_BAR2_REG_IDX] = {


### PR DESCRIPTION
closes #13, #17 