### PR TITLE
rename VFU_REG_FLAG_*

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -305,12 +305,11 @@ vfu_pci_setup_config_hdr(vfu_ctx_t *vfu_ctx, vfu_pci_hdr_id_t id,
 int
 vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
 
-// Region flags.
-#define VFU_REG_FLAG_READ    (1 << 0)
-#define VFU_REG_FLAG_WRITE   (1 << 1)
-#define VFU_REG_FLAG_MMAP    (1 << 2)    // TODO: how this relates to IO bar?
-#define VFU_REG_FLAG_RW      (VFU_REG_FLAG_READ | VFU_REG_FLAG_WRITE)
-#define VFU_REG_FLAG_MEM     (1 << 3)    // if unset, bar is IO
+#define VFU_REGION_FLAG_READ    (1 << 0)
+#define VFU_REGION_FLAG_WRITE   (1 << 1)
+#define VFU_REGION_FLAG_MMAP    (1 << 2)    // TODO: how this relates to IO bar?
+#define VFU_REGION_FLAG_RW      (VFU_REGION_FLAG_READ | VFU_REGION_FLAG_WRITE)
+#define VFU_REGION_FLAG_MEM     (1 << 3)    // if unset, bar is IO
 
 /**
  * Prototype for region access callback. When a region is accessed, libvfio-user

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1104,7 +1104,7 @@ prepare_ctx(vfu_ctx_t *vfu_ctx)
     // Set a default config region if none provided.
     /* TODO should it be enough to check that the size of region is 0? */
     if (memcmp(cfg_reg, &zero_reg, sizeof(*cfg_reg)) == 0) {
-        cfg_reg->flags = VFU_REG_FLAG_RW;
+        cfg_reg->flags = VFU_REGION_FLAG_RW;
         cfg_reg->size = PCI_CFG_SPACE_SIZE;
     }
 
@@ -1118,7 +1118,7 @@ prepare_ctx(vfu_ctx_t *vfu_ctx)
 
     // Set type for region registers.
     for (i = 0; i < PCI_BARS_NR; i++) {
-        if (!(vfu_ctx->reg_info[i].flags & VFU_REG_FLAG_MEM)) {
+        if (!(vfu_ctx->reg_info[i].flags & VFU_REGION_FLAG_MEM)) {
             vfu_ctx->pci_config_space->hdr.bars[i].io.region_type |= 0x1;
         }
     }
@@ -1481,7 +1481,7 @@ vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
     case VFU_PCI_DEV_BAR0_REGION_IDX ... VFU_PCI_DEV_VGA_REGION_IDX:
         // Validate the config region provided.
         if (region_idx == VFU_PCI_DEV_CFG_REGION_IDX &&
-            flags != VFU_REG_FLAG_RW) {
+            flags != VFU_REGION_FLAG_RW) {
             return ERROR(EINVAL);
         }
 
@@ -1583,7 +1583,7 @@ vfu_setup_device_migration(vfu_ctx_t *vfu_ctx, vfu_migration_t *migration)
         return ERROR(-ret);
     }
 
-    migr_reg->flags = VFU_REG_FLAG_RW;
+    migr_reg->flags = VFU_REGION_FLAG_RW;
     migr_reg->size = sizeof(struct vfio_device_migration_info) + migration->size;
 
     vfu_ctx->migration = init_migration(migration, &ret);

--- a/lib/pci.c
+++ b/lib/pci.c
@@ -68,7 +68,7 @@ vfu_pci_hdr_write_bar(vfu_ctx_t *vfu_ctx, uint16_t bar_index, const char *buf)
         cfg_addr = ~(reg_info[bar_index].size) + 1;
     }
 
-    if ((reg_info[bar_index].flags & VFU_REG_FLAG_MEM)) {
+    if ((reg_info[bar_index].flags & VFU_REGION_FLAG_MEM)) {
         mask = PCI_BASE_ADDRESS_MEM_MASK;
     } else {
         mask = PCI_BASE_ADDRESS_IO_MASK;

--- a/lib/private.h
+++ b/lib/private.h
@@ -75,7 +75,7 @@ struct vfu_sparse_mmap_areas {
 typedef struct  {
 
     /*
-     * Region flags, see VFU_REG_FLAG_XXX above.
+     * Region flags, see VFU_REGION_FLAG_READ and friends.
      */
     uint32_t            flags;
 
@@ -93,7 +93,7 @@ typedef struct  {
 
     /*
      * Callback function that is called when the region is memory mapped.
-     * Required if VFU_REG_FLAG_MEM is set, otherwise ignored.
+     * Required if VFU_REGION_FLAG_MEM is set, otherwise ignored.
      */
     vfu_map_region_cb_t     *map;
     struct vfu_sparse_mmap_areas *mmap_areas; /* sparse mmap areas */

--- a/lib/python_bindings.c
+++ b/lib/python_bindings.c
@@ -195,9 +195,9 @@ libvfio_user_run(PyObject *self, PyObject *args, PyObject *kwargs)
         if (_ri[i].perm != NULL) {
             for (j = 0; j < strlen(_ri[i].perm); j++) {
                 if (_ri[i].perm[j] == 'r') {
-                    flags |= VFU_REG_FLAG_READ;
+                    flags |= VFU_REGION_FLAG_READ;
                 } else if (_ri[i].perm[j] == 'w') {
-                    flags |= VFU_REG_FLAG_WRITE;
+                    flags |= VFU_REGION_FLAG_WRITE;
                 } else {
                     /* FIXME shouldn't print to stderr */
                     fprintf(stderr, "bad permission '%c'\n", _ri[i].perm[j]);

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -122,7 +122,7 @@ main(int argc, char *argv[])
     }
 
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR2_REGION_IDX, 0x100,
-                           &bar2_access, VFU_REG_FLAG_RW, NULL, 0, NULL);
+                           &bar2_access, VFU_REGION_FLAG_RW, NULL, 0, NULL);
     if (ret < 0) {
         fprintf(stderr, "failed to setup region\n");
         goto out;

--- a/samples/server.c
+++ b/samples/server.c
@@ -429,7 +429,7 @@ int main(int argc, char *argv[])
     }
 
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX, sizeof(time_t),
-                           &bar0_access, VFU_REG_FLAG_RW, NULL, 0, NULL);
+                           &bar0_access, VFU_REGION_FLAG_RW, NULL, 0, NULL);
     if (ret < 0) {
         err(EXIT_FAILURE, "failed to setup BAR0 region");
     }
@@ -440,7 +440,7 @@ int main(int argc, char *argv[])
     };
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR1_REGION_IDX,
                            sysconf(_SC_PAGESIZE), &bar1_access,
-                           VFU_REG_FLAG_RW, mmap_areas, 2, map_area);
+                           VFU_REGION_FLAG_RW, mmap_areas, 2, map_area);
     if (ret < 0) {
         err(EXIT_FAILURE, "failed to setup BAR1 region");
     }


### PR DESCRIPTION
We renamed other code to be "REGION" instead of "REG" so it's less ambiguous. Do
the same for VFU_REG_FLAG_*.

Signed-off-by: John Levon <john.levon@nutanix.com>