### PR TITLE
draft

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -305,7 +305,7 @@ vfu_pci_set_class(vfu_ctx_t *vfu_ctx, uint8_t base, uint8_t sub, uint8_t pi);
  */
 int
 vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, uint16_t cap_id, bool extended,
-                       void *data, size_t size);
+                       void *data);
 
 /**
  * Callback function that gets called when a capability is accessed.
@@ -334,6 +334,9 @@ typedef ssize_t (vfu_cap_access_cb_t) (void *pvt, uint8_t id,
  * and PCI_EXT_CAP_ID_VNDR), this can be used to add a capability where reads
  * and writes are delegated to a callback.
  *
+ * Note the size of the capability is derived either from the ID, or from an
+ * embedded length field for PCI_(EXT_)CAP_ID_VNDR.
+ *
  * @vfu_ctx: the libvfio-user context
  * @cap: capability ID to add
  * @extended: true if an extended capability (PCI_EXT_CAP_ID_*)
@@ -342,7 +345,7 @@ typedef ssize_t (vfu_cap_access_cb_t) (void *pvt, uint8_t id,
  */
 int
 vfu_pci_add_capability_cb(vfu_ctx_t *vfu_ctx, uint16_t cap_id, bool extended,
-                          size_t size, vfu_cap_access_cb_t cb, void *pvt);
+                          vfu_cap_access_cb_t cb, void *pvt);
 
 #define VFU_REGION_FLAG_READ    (1 << 0)
 #define VFU_REGION_FLAG_WRITE   (1 << 1)

--- a/include/pci.h
+++ b/include/pci.h
@@ -177,6 +177,7 @@ typedef union {
 } __attribute__ ((packed)) vfu_pci_hdr_t;
 _Static_assert(sizeof(vfu_pci_hdr_t) == 0x40, "bad PCI header size");
 
+/* FIXME: get rid of these, they don't seem to have much value? */
 typedef struct {
     uint8_t raw[PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF];
 } __attribute__ ((packed)) vfu_pci_non_std_config_space_t;


### PR DESCRIPTION
Here's roughly where I got to.

I realised my plan yesterday had a potentially fatal flaw - we can't add callbacks for caps if we don't have the ctx to add them to. So I reworked it instead to be used like this:

```
// allocs, inits, and stores the whole cfg space, returning a pointer to it
vfu_pci_hdr_t *space = vfu_pci_init(ctx, ...);

// use helpers
vfu_pci_set_id(ctx, PCI_ID_NVME_FOO,...);
vfu_pci_set_class(ctx, STORAGE_NVME_CLASS, NVME_SUBCLASS, ...);
vfu_pci_add_capability(ctx, PCI_CAP_ID_EXP, false, pxcap, sizeof (*pxcap));

...

vfu_ctx_drive();

I don't see the need to support anything other than Type 0 header - thoughts?

Thanos - you were right, there's no need at all for a 'size' parameter.

There are several FIXME comments below I'd be interested in your opinions on. In general, we should take a look at what spdk needs to do - currently it has a callback for all of extended config space!