### PR TITLE
replace travis with github actions

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -4,15 +4,16 @@ jobs:
   ubuntu-20:
     runs-on: ubuntu-20.04
     steps:
+      - uses: actions/checkout@v2
       - name: pre-push
         run: |
           sudo apt-get -y install libjson-c-dev libcmocka-dev
-          make pre-push
-  ubuntu-16:
-    runs-on: ubuntu-16.04
+          make pre-push VERBOSE=1
+  ubuntu-18:
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: pre-push
         run: |
           sudo apt-get -y install libjson-c-dev libcmocka-dev
-          make pre-push
+          make pre-push VERBOSE=1

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,6 +11,7 @@ jobs:
   ubuntu-16:
     runs-on: ubuntu-16.04
     steps:
+      - uses: actions/checkout@v2
       - name: pre-push
         run: |
           sudo apt-get -y install libjson-c-dev libcmocka-dev

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,17 @@
+name: pull_request
+on: pull_request
+jobs:
+  ubuntu-20.04:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: pre-push
+        run: |
+          sudo apt-get -y install libjson-c-dev libcmocka-dev
+          make pre-push
+  ubuntu-16.04:
+    runs-on: ubuntu-16.04
+    steps:
+      - name: pre-push
+        run: |
+          sudo apt-get -y install libjson-c-dev libcmocka-dev
+          make pre-push

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,14 +1,14 @@
 name: pull_request
 on: pull_request
 jobs:
-  ubuntu-20.04:
+  ubuntu-20:
     runs-on: ubuntu-20.04
     steps:
       - name: pre-push
         run: |
           sudo apt-get -y install libjson-c-dev libcmocka-dev
           make pre-push
-  ubuntu-16.04:
+  ubuntu-16:
     runs-on: ubuntu-16.04
     steps:
       - name: pre-push

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,0 @@
-language: c
-dist: bionic
-compiler: gcc
-before_install:
-  - sudo apt-get -y install libjson-c-dev libcmocka-dev
-script:
-  - make pre-push


### PR DESCRIPTION
Travis is closing down their free tier; stop using it.

Signed-off-by: John Levon <john.levon@nutanix.com>