### PR TITLE
[draft] Drop vfu_ctx_drive() and use vfu_ctx_poll()

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -438,10 +438,10 @@ vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
 /**
  * Polls the vfu_ctx and processes the command recieved from client.
  * - Blocking vfu_ctx:
- *   Blocks until new request is recieved from client and continues processing
+ *   Blocks until new request is received from client and continues processing
  *   the requests. Exits only in case of error or if the client disconnects.
  * - Non-blocking vfu_ctx(LIBVFIO_USER_FLAG_ATTACH_NB):
- *   Processes one request from client if its available, otherwise it
+ *   Processes one request from client if it's available, otherwise it
  *   immediatelly returns and the caller is responsible for periodically
  *   calling again.
  *

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -446,7 +446,7 @@ vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
  * @returns 0 on success, -errno on failure.
  */
 int
-vfu_ctx_poll(vfu_ctx_t *vfu_ctx);
+vfu_run_ctx(vfu_ctx_t *vfu_ctx);
 
 /**
  * Triggers an interrupt.
@@ -603,7 +603,7 @@ vfu_realize_ctx(vfu_ctx_t *vfu_ctx);
 
 /*
  * Attempts to attach to the transport. Attach is mandatory before
- * vfu_ctx_poll() and is non blocking if context is created
+ * vfu_run_ctx() and is non blocking if context is created
  * with LIBVFIO_USER_FLAG_ATTACH_NB flag.
  * Returns client's file descriptor on success and -1 on error. If errno is
  * set to EAGAIN or EWOULDBLOCK then the transport is not ready to attach to and

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -437,9 +437,13 @@ vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
 
 /**
  * Polls the vfu_ctx and processes the command recieved from client.
- * Non-blocking poll if vfu_ctx is created with LIBVFIO_USER_FLAG_ATTACH_NB,
- * otherwise blocking. With non-blocking poll application can periodically poll
- * the context directly from one of its own threads.
+ * - Blocking vfu_ctx:
+ *   Blocks until new request is recieved from client and continues processing
+ *   the requests. Exits only in case of error or if the client disconnects.
+ * - Non-blocking vfu_ctx(LIBVFIO_USER_FLAG_ATTACH_NB):
+ *   Processes one request from client if its available, otherwise it
+ *   immediatelly returns and the caller is responsible for periodically
+ *   calling again.
  *
  * @vfu_ctx: The libvfio-user context to poll
  *

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -436,24 +436,10 @@ void
 vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
 
 /**
- * Once the vfu_ctx is configured vfu_ctx_drive() drives it. This function waits
- * for commands coming from the client, and processes them in a loop.
- *
- * @vfu_ctx: the libvfio-user context to drive
- *
- * @returns 0 on success, -errno on failure.
- */
-int
-vfu_ctx_drive(vfu_ctx_t *vfu_ctx);
-
-/**
- * Polls, without blocking, an vfu_ctx. This is an alternative to using
- * a thread and making a blocking call to vfu_ctx_drive(). Instead, the
- * application can periodically poll the context directly from one of
- * its own threads.
- *
- * This is only allowed when LIBVFIO_USER_FLAG_ATTACH_NB is specified during
- * creation.
+ * Polls the vfu_ctx and processes the command recieved from client.
+ * Non-blocking poll if vfu_ctx is created with LIBVFIO_USER_FLAG_ATTACH_NB,
+ * otherwise blocking. With non-blocking poll application can periodically poll
+ * the context directly from one of its own threads.
  *
  * @vfu_ctx: The libvfio-user context to poll
  *
@@ -617,7 +603,7 @@ vfu_realize_ctx(vfu_ctx_t *vfu_ctx);
 
 /*
  * Attempts to attach to the transport. Attach is mandatory before
- * vfu_ctx_drive() or vfu_ctx_poll() and is non blocking if context is created
+ * vfu_ctx_poll() and is non blocking if context is created
  * with LIBVFIO_USER_FLAG_ATTACH_NB flag.
  * Returns client's file descriptor on success and -1 on error. If errno is
  * set to EAGAIN or EWOULDBLOCK then the transport is not ready to attach to and

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1162,34 +1162,18 @@ vfu_realize_ctx(vfu_ctx_t *vfu_ctx)
 }
 
 int
-vfu_ctx_drive(vfu_ctx_t *vfu_ctx)
+vfu_ctx_poll(vfu_ctx_t *vfu_ctx)
 {
     int err;
+    int blocking = vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB ? 0 : 1;
 
-    if (vfu_ctx == NULL || !vfu_ctx->realized) {
+    if (!vfu_ctx->realized) {
         return ERROR(EINVAL);
     }
 
     do {
         err = process_request(vfu_ctx);
-    } while (err >= 0);
-
-    return err;
-}
-
-int
-vfu_ctx_poll(vfu_ctx_t *vfu_ctx)
-{
-    int err;
-
-    if (unlikely((vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB) == 0)) {
-        return -ENOTSUP;
-    }
-
-    if (!vfu_ctx->realized) {
-        return ERROR(EINVAL);
-    }
-    err = process_request(vfu_ctx);
+    } while (err >= 0 && blocking);
 
     return err >= 0 ? 0 : err;
 }

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1167,7 +1167,7 @@ int
 vfu_run_ctx(vfu_ctx_t *vfu_ctx)
 {
     int err;
-    bool blocking = !(vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB);
+    bool blocking;
 
     assert(vfu_ctx != NULL);
 
@@ -1175,6 +1175,7 @@ vfu_run_ctx(vfu_ctx_t *vfu_ctx)
         return ERROR(EINVAL);
     }
 
+    blocking = !(vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB);
     do {
         err = process_request(vfu_ctx);
     } while (err >= 0 && blocking);

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1164,7 +1164,7 @@ vfu_realize_ctx(vfu_ctx_t *vfu_ctx)
 }
 
 int
-vfu_ctx_poll(vfu_ctx_t *vfu_ctx)
+vfu_run_ctx(vfu_ctx_t *vfu_ctx)
 {
     int err;
     bool blocking = !(vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB);

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1079,6 +1079,8 @@ process_request(vfu_ctx_t *vfu_ctx)
 
     return ret;
 }
+UNIT_TEST_SYMBOL(process_request);
+#define process_request __wrap_process_request
 
 int
 vfu_realize_ctx(vfu_ctx_t *vfu_ctx)
@@ -1165,7 +1167,9 @@ int
 vfu_ctx_poll(vfu_ctx_t *vfu_ctx)
 {
     int err;
-    int blocking = vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB ? 0 : 1;
+    bool blocking = !(vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB);
+
+    assert(vfu_ctx != NULL);
 
     if (!vfu_ctx->realized) {
         return ERROR(EINVAL);

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to attach device");
     }
 
-    ret = vfu_ctx_drive(vfu_ctx);
+    ret = vfu_ctx_poll(vfu_ctx);
     if (ret != 0) {
         if (ret != -ENOTCONN && ret != -EINTR) {
             fprintf(stderr, "failed to realize device emulation\n");

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -143,7 +143,7 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to attach device");
     }
 
-    ret = vfu_ctx_poll(vfu_ctx);
+    ret = vfu_run_ctx(vfu_ctx);
     if (ret != 0) {
         if (ret != -ENOTCONN && ret != -EINTR) {
             fprintf(stderr, "failed to realize device emulation\n");

--- a/samples/null.c
+++ b/samples/null.c
@@ -73,7 +73,7 @@ static void* null_drive(void *arg)
         return NULL;
     }
     printf("starting device emulation\n");
-    vfu_ctx_poll(vfu_ctx);
+    vfu_run_ctx(vfu_ctx);
     return NULL;
 }
 

--- a/samples/null.c
+++ b/samples/null.c
@@ -73,7 +73,7 @@ static void* null_drive(void *arg)
         return NULL;
     }
     printf("starting device emulation\n");
-    vfu_ctx_drive(vfu_ctx);
+    vfu_ctx_poll(vfu_ctx);
     return NULL;
 }
 

--- a/samples/server.c
+++ b/samples/server.c
@@ -496,7 +496,7 @@ int main(int argc, char *argv[])
     }
 
     do {
-        ret = vfu_ctx_poll(vfu_ctx);
+        ret = vfu_run_ctx(vfu_ctx);
         if (ret == -EINTR) {
             if (irq_triggered) {
                 irq_triggered = false;

--- a/samples/server.c
+++ b/samples/server.c
@@ -496,7 +496,7 @@ int main(int argc, char *argv[])
     }
 
     do {
-        ret = vfu_ctx_drive(vfu_ctx);
+        ret = vfu_ctx_poll(vfu_ctx);
         if (ret == -EINTR) {
             if (irq_triggered) {
                 irq_triggered = false;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -52,6 +52,7 @@ target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=exec_command")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=close")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=vfu_send_iovec")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=free")
+target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=process_request")
 
 enable_testing()
 add_test(NAME unit-tests COMMAND unit-tests)

--- a/test/mocks.c
+++ b/test/mocks.c
@@ -37,6 +37,7 @@
 #include "mocks.h"
 #include "dma.h"
 #include "migration.h"
+#include "../lib/private.h"
 
 struct function
 {
@@ -147,6 +148,18 @@ __wrap_free(void *ptr)
     check_expected(ptr);
 }
 
+int
+__wrap_process_request(vfu_ctx_t *vfu_ctx)
+{
+
+    if (!is_patched(process_request)) {
+        return __real_process_request(vfu_ctx);
+    }
+    check_expected(vfu_ctx);
+
+    return mock();
+}
+
 /* FIXME should be something faster than unsorted array, look at tsearch(3). */
 static struct function funcs[] = {
     {.addr = &__wrap_dma_controller_add_region},
@@ -157,7 +170,8 @@ static struct function funcs[] = {
     {.addr = &__wrap_exec_command},
     {.addr = &__wrap_close},
     {.addr = &__wrap_vfu_send_iovec},
-    {.addr = &__wrap_free}
+    {.addr = &__wrap_free},
+    {.addr = &__wrap_process_request}
 };
 
 static struct function*

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -366,14 +366,14 @@ test_attach_ctx(void **state __attribute__((unused)))
 }
 
 static void
-test_ctx_poll(UNUSED void **state)
+test_run_ctx(UNUSED void **state)
 {
     vfu_ctx_t vfu_ctx = {
         .realized = false,
     };
 
     // device un-realized
-    assert_int_equal(-1, vfu_ctx_poll(&vfu_ctx));
+    assert_int_equal(-1, vfu_run_ctx(&vfu_ctx));
 
     // device realized, with NB vfu_ctx
     vfu_ctx.realized = true;
@@ -382,7 +382,7 @@ test_ctx_poll(UNUSED void **state)
     patch(process_request);
     expect_value(__wrap_process_request, vfu_ctx, &vfu_ctx);
     will_return(__wrap_process_request, 0);
-    assert_int_equal(0, vfu_ctx_poll(&vfu_ctx));
+    assert_int_equal(0, vfu_run_ctx(&vfu_ctx));
 
     // device realized, with blocking vfu_ctx
     vfu_ctx.flags = 0;
@@ -391,7 +391,7 @@ test_ctx_poll(UNUSED void **state)
 
     expect_value(__wrap_process_request, vfu_ctx, &vfu_ctx);
     will_return(__wrap_process_request, -1);
-    assert_int_equal(-1, vfu_ctx_poll(&vfu_ctx));
+    assert_int_equal(-1, vfu_run_ctx(&vfu_ctx));
 }
 
 /*
@@ -419,7 +419,7 @@ int main(void)
         cmocka_unit_test_setup(test_process_command_free_passed_fds, setup),
         cmocka_unit_test_setup(test_realize_ctx, setup),
         cmocka_unit_test_setup(test_attach_ctx, setup),
-        cmocka_unit_test_setup(test_ctx_poll, setup)
+        cmocka_unit_test_setup(test_run_ctx, setup)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);


### PR DESCRIPTION
Updated vfu_ctx_poll() to also handle blocking ctx.
Instead of having seperate functions for blocking and
non-blocking ctx, better to have one.
This way user can call same set of functions for both cases.

Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>