### PR TITLE
remove vfu_get_pci_non_std_config_space()

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -99,7 +99,12 @@ void *
 vfu_mmap(vfu_ctx_t * vfu_ctx, off_t offset, size_t length);
 
 /*
- * Returns a pointer to the standard part of the PCI configuration space.
+ * Returns a pointer to the PCI configuration space.
+ *
+ * PCI config space consists of an initial 64-byte vfu_pci_hdr_t, plus
+ * additional space, either containing capabilities, or device-specific
+ * configuration.  Standard confspace is 256 bytes; extended config space is
+ * 4096 bytes.
  */
 vfu_pci_config_space_t *
 vfu_pci_get_config_space(vfu_ctx_t *vfu_ctx);
@@ -569,17 +574,6 @@ vfu_dma_read(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data);
  */
 int
 vfu_dma_write(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data);
-
-/*
- * Advanced stuff.
- */
-
-/**
- * Returns the non-standard part of the PCI configuration space.
- * @vfu_ctx: the libvfio-user context
- */
-uint8_t *
-vfu_get_pci_non_std_config_space(vfu_ctx_t *vfu_ctx);
 
 /*
  * Finalizes the device making it ready for vfu_attach_ctx(). This function is

--- a/include/pci.h
+++ b/include/pci.h
@@ -177,19 +177,13 @@ typedef union {
 } __attribute__ ((packed)) vfu_pci_hdr_t;
 _Static_assert(sizeof(vfu_pci_hdr_t) == 0x40, "bad PCI header size");
 
-typedef struct {
-    uint8_t raw[PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF];
-} __attribute__ ((packed)) vfu_pci_non_std_config_space_t;
-_Static_assert(sizeof(vfu_pci_non_std_config_space_t) == 0xc0,
-               "bad non-standard PCI configuration space size");
-
+/*
+ * Note that extended config space is 4096 bytes.
+ */
 typedef struct {
     union {
         uint8_t raw[PCI_CFG_SPACE_SIZE];
-        struct {
-            vfu_pci_hdr_t hdr;
-            vfu_pci_non_std_config_space_t non_std;
-        } __attribute__ ((packed));
+        vfu_pci_hdr_t hdr;
     } __attribute__ ((packed));
     uint8_t extended[];
 } __attribute__ ((packed)) vfu_pci_config_space_t;

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1590,23 +1590,13 @@ vfu_setup_device_migration(vfu_ctx_t *vfu_ctx, vfu_migration_t *migration)
 }
 
 /*
- * Returns a pointer to the standard part of the PCI configuration space.
+ * Returns a pointer to the PCI configuration space.
  */
 inline vfu_pci_config_space_t *
 vfu_pci_get_config_space(vfu_ctx_t *vfu_ctx)
 {
     assert(vfu_ctx != NULL);
     return vfu_ctx->pci.config_space;
-}
-
-/*
- * Returns a pointer to the non-standard part of the PCI configuration space.
- */
-inline uint8_t *
-vfu_get_pci_non_std_config_space(vfu_ctx_t *vfu_ctx)
-{
-    assert(vfu_ctx != NULL);
-    return (uint8_t *)&vfu_ctx->pci.config_space->non_std;
 }
 
 inline vfu_reg_info_t *


### PR DESCRIPTION
Remove this API as well as vfu_pci_non_std_config_space_t. It's at best
confusing to try to represent this area as if it's not just a normal part of the
overall config space, and we don't really want an additional API for the
extended space past either.

Signed-off-by: John Levon <john.levon@nutanix.com>