### PR TITLE
clean up the API header file

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -57,6 +57,8 @@ extern "C" {
 #define LIB_VFIO_USER_MAJOR 0
 #define LIB_VFIO_USER_MINOR 1
 
+#define VFU_DMA_REGIONS  0x10
+
 // FIXME: too common a name?
 typedef uint64_t dma_addr_t;
 
@@ -68,6 +70,122 @@ typedef struct {
 } dma_sg_t;
 
 typedef struct vfu_ctx vfu_ctx_t;
+
+/*
+ * Attaching to the transport is non-blocking.
+ * The caller must then manually call vfu_attach_ctx(),
+ * which is non-blocking, as many times as necessary.
+ */
+#define LIBVFIO_USER_FLAG_ATTACH_NB  (1 << 0)
+
+typedef enum {
+    VFU_TRANS_SOCK,
+    VFU_TRANS_MAX
+} vfu_trans_t;
+
+typedef enum {
+    VFU_DEV_TYPE_PCI
+} vfu_dev_type_t;
+
+/**
+ * Creates libvfio-user context.
+ *
+ * @trans: transport type
+ * @path: path to socket file.
+ * @flags: context flags
+ * @pvt: private data
+ * @dev_type: device type
+ *
+ * @returns the vfu_ctx to be used or NULL on error. Sets errno.
+ */
+vfu_ctx_t *
+vfu_create_ctx(vfu_trans_t trans, const char *path,
+               int flags, void *pvt, vfu_dev_type_t dev_type);
+
+/*
+ * Finalizes the device making it ready for vfu_attach_ctx(). This function is
+ * mandatory to be called before vfu_attach_ctx().
+ * @vfu_ctx: the libvfio-user context
+ *
+ * @returns: 0 on success, -1 on error. Sets errno.
+ */
+int
+vfu_realize_ctx(vfu_ctx_t *vfu_ctx);
+
+/*
+ * Attempts to attach to the transport. Attach is mandatory before
+ * vfu_run_ctx() and is non blocking if context is created
+ * with LIBVFIO_USER_FLAG_ATTACH_NB flag.
+ * Returns client's file descriptor on success and -1 on error. If errno is
+ * set to EAGAIN or EWOULDBLOCK then the transport is not ready to attach to and
+ * the operation must be retried.
+ *
+ * @vfu_ctx: the libvfio-user context
+ */
+int
+vfu_attach_ctx(vfu_ctx_t *vfu_ctx);
+
+/**
+ * Polls the vfu_ctx and processes the command recieved from client.
+ * - Blocking vfu_ctx:
+ *   Blocks until new request is received from client and continues processing
+ *   the requests. Exits only in case of error or if the client disconnects.
+ * - Non-blocking vfu_ctx(LIBVFIO_USER_FLAG_ATTACH_NB):
+ *   Processes one request from client if it's available, otherwise it
+ *   immediatelly returns and the caller is responsible for periodically
+ *   calling again.
+ *
+ * @vfu_ctx: The libvfio-user context to poll
+ *
+ * @returns 0 on success, -errno on failure.
+ */
+int
+vfu_run_ctx(vfu_ctx_t *vfu_ctx);
+
+/**
+ * Destroys libvfio-user context.
+ *
+ * @vfu_ctx: the libvfio-user context to destroy
+ */
+void
+vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
+
+/**
+ * Callback function signature for log function
+ * @pvt: private pointer
+ * @level: log level as defined in syslog(3)
+ * @vfu_log_fn_t: typedef for log function.
+ * @msg: message
+ */
+typedef void (vfu_log_fn_t) (void *pvt, int level, const char *msg);
+
+/**
+ * Log to the logging function configured for this context.
+ */
+void
+vfu_log(vfu_ctx_t *vfu_ctx, int level, const char *fmt, ...);
+
+/**
+ * Setup logging information.
+ * @vfu_ctx: the libvfio-user context
+ * @log: logging function
+ * @level: logging level as defined in syslog(3)
+ */
+int
+vfu_setup_log(vfu_ctx_t *vfu_ctx, vfu_log_fn_t *log, int level);
+
+/**
+ * Creates a mapping of a device region into the caller's virtual memory. It
+ * must be called by vfu_map_region_cb_t.
+ *
+ * @vfu_ctx: the context to create mapping from
+ * @offset: offset of the region being mapped
+ * @length: size of the region being mapped
+ *
+ * @returns a pointer to the requested memory or MAP_FAILED on error. Sets errno.
+ */
+void *
+vfu_mmap(vfu_ctx_t * vfu_ctx, off_t offset, size_t length);
 
 /**
  * Prototype for memory access callback. The program MUST first map device
@@ -85,47 +203,114 @@ typedef struct vfu_ctx vfu_ctx_t;
 typedef unsigned long (vfu_map_region_cb_t) (void *pvt, unsigned long off,
                                              unsigned long len);
 
+#define VFU_REGION_FLAG_READ    (1 << 0)
+#define VFU_REGION_FLAG_WRITE   (1 << 1)
+#define VFU_REGION_FLAG_MMAP    (1 << 2)    // TODO: how this relates to IO bar?
+#define VFU_REGION_FLAG_RW      (VFU_REGION_FLAG_READ | VFU_REGION_FLAG_WRITE)
+#define VFU_REGION_FLAG_MEM     (1 << 3)    // if unset, bar is IO
+
 /**
- * Creates a mapping of a device region into the caller's virtual memory. It
- * must be called by vfu_map_region_cb_t.
+ * Prototype for region access callback. When a region is accessed, libvfio-user
+ * calls the previously registered callback with the following arguments:
  *
- * @vfu_ctx: the context to create mapping from
- * @offset: offset of the region being mapped
- * @length: size of the region being mapped
+ * @pvt: private data originally passed by vfu_create_ctx()
+ * @buf: buffer containing the data to be written or data to be read into
+ * @count: number of bytes being read or written
+ * @offset: byte offset within the region
+ * @is_write: whether or not this is a write
  *
- * @returns a pointer to the requested memory or MAP_FAILED on error. Sets errno.
+ * @returns the number of bytes read or written, or a negative integer on error
  */
-void *
-vfu_mmap(vfu_ctx_t * vfu_ctx, off_t offset, size_t length);
+typedef ssize_t (vfu_region_access_cb_t) (void *pvt, char *buf, size_t count,
+                                          loff_t offset, bool is_write);
+
+/**
+ * Set up a region.
+ *
+ * If this is the PCI configuration space, the @size argument is ignored. The
+ * size of the region is determined by the PCI type (set when the libvfio-user
+ * context is created). Accesses to the PCI configuration space header and the
+ * PCI capabilities are handled internally; the user supplied callback is not
+ * called.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @region_idx: region index
+ * @size: size of the region
+ * @region_access: callback function to access region
+ * @flags: region  flags
+ * @mmap_areas: array of memory mappable areas
+ * @nr_mmap_areas: size of mmap_areas
+ * @map: callback function to map region
+ *
+ * @returns 0 on success, -1 on error, Sets errno.
+ */
+int
+vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
+                 vfu_region_access_cb_t *region_access, int flags,
+                 struct iovec *mmap_areas, uint32_t nr_mmap_areas,
+                 vfu_map_region_cb_t *map);
 
 /*
- * Returns a pointer to the PCI configuration space.
- *
- * PCI config space consists of an initial 64-byte vfu_pci_hdr_t, plus
- * additional space, either containing capabilities, or device-specific
- * configuration.  Standard confspace is 256 bytes; extended config space is
- * 4096 bytes.
+ * Callback function that is called when the guest resets the device.
+ * @pvt: private pointer
  */
-vfu_pci_config_space_t *
-vfu_pci_get_config_space(vfu_ctx_t *vfu_ctx);
-
-#define VFU_DMA_REGIONS  0x10
+typedef int (vfu_reset_cb_t) (void *pvt);
 
 /**
- * Callback function signature for log function
- * @pvt: private pointer
- * @level: log level as defined in syslog(3)
- * @vfu_log_fn_t: typedef for log function.
- * @msg: message
+ * Setup device reset callback.
+ * @vfu_ctx: the libvfio-user context
+ * @reset: device reset callback (optional)
  */
-typedef void (vfu_log_fn_t) (void *pvt, int level, const char *msg);
+int
+vfu_setup_device_reset_cb(vfu_ctx_t *vfu_ctx, vfu_reset_cb_t *reset);
 
-typedef enum {
-    VFU_TRANS_SOCK,
-    VFU_TRANS_MAX
-} vfu_trans_t;
+/*
+ * Function that is called when the guest maps a DMA region. Optional.
+ * @pvt: private pointer
+ * @iova: iova address
+ * @len: length
+ */
+typedef void (vfu_map_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
 
-#define VFU_MAX_CAPS (PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF) / PCI_CAP_SIZEOF
+/*
+ * Function that is called when the guest unmaps a DMA region. The device
+ * must release all references to that region before the callback returns.
+ * This is required if you want to be able to access guest memory.
+ * @pvt: private pointer
+ * @iova: iova address
+ * @len: length
+ */
+typedef int (vfu_unmap_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
+
+/**
+ * Setup device DMA map/unmap callbacks.
+ * @vfu_ctx: the libvfio-user context
+ * @map_dma: DMA region map callback (optional)
+ * @unmap_dma: DMA region unmap callback (optional)
+ */
+
+int
+vfu_setup_device_dma_cb(vfu_ctx_t *vfu_ctx, vfu_map_dma_cb_t *map_dma,
+                        vfu_unmap_dma_cb_t *unmap_dma);
+
+enum vfu_dev_irq_type {
+    VFU_DEV_INTX_IRQ,
+    VFU_DEV_MSI_IRQ,
+    VFU_DEV_MSIX_IRQ,
+    VFU_DEV_ERR_IRQ,
+    VFU_DEV_REQ_IRQ,
+    VFU_DEV_NUM_IRQS
+};
+
+/**
+ * Setup device IRQ counts.
+ * @vfu_ctx: the libvfio-user context
+ * @type: IRQ type (VFU_DEV_INTX_IRQ ... VFU_DEV_REQ_IRQ)
+ * @count: number of irqs
+ */
+int
+vfu_setup_device_nr_irqs(vfu_ctx_t *vfu_ctx, enum vfu_dev_irq_type type,
+                         uint32_t count);
 
 /*
  * FIXME the names of migration callback functions are probably far too long,
@@ -200,215 +385,6 @@ typedef struct {
     uint32_t                    nr_mmap_areas;
 } vfu_migration_t;
 
-/*
- * Attaching to the transport is non-blocking.
- * The caller must then manually call vfu_attach_ctx(),
- * which is non-blocking, as many times as necessary.
- */
-#define LIBVFIO_USER_FLAG_ATTACH_NB  (1 << 0)
-
-typedef enum {
-    VFU_DEV_TYPE_PCI
-} vfu_dev_type_t;
-
-/**
- * Creates libvfio-user context.
- *
- * @trans: transport type
- * @path: path to socket file.
- * @flags: context flag
- * @pvt: private data
- * @dev_type: device type
- *
- * @returns the vfu_ctx to be used or NULL on error. Sets errno.
- */
-vfu_ctx_t *
-vfu_create_ctx(vfu_trans_t trans, const char *path,
-               int flags, void *pvt, vfu_dev_type_t dev_type);
-
-
-/**
- * Setup logging information.
- * @vfu_ctx: the libvfio-user context
- * @log: logging function
- * @level: logging level as defined in syslog(3)
- */
-int
-vfu_setup_log(vfu_ctx_t *vfu_ctx, vfu_log_fn_t *log, int level);
-
-//TODO: Check other PCI header registers suitable to be filled by device.
-//      Or should we pass whole vfu_pci_hdr_t to be filled by user.
-
-typedef enum {
-    VFU_PCI_TYPE_CONVENTIONAL,
-    VFU_PCI_TYPE_PCI_X_1,
-    VFU_PCI_TYPE_PCI_X_2,
-    VFU_PCI_TYPE_EXPRESS
-} vfu_pci_type_t;
-
-/**
- * Setup PCI configuration space header data. This function must be called only
- * once per libvfio-user context.
- *
- * @vfu_ctx: the libvfio-user context
- * @id: Device and vendor ID
- * @ss: Subsystem vendor and device ID
- * @cc: Class code
- * @pci_type: PCI type (convention PCI, PCI-X mode 1, PCI-X mode2, PCI-Express)
- * @revision: PCI/PCI-X/PCIe revision
- *
- * @returns 0 on success, -1 on failure and sets errno.
- */
-int
-vfu_pci_setup_config_hdr(vfu_ctx_t *vfu_ctx, vfu_pci_hdr_id_t id,
-                         vfu_pci_hdr_ss_t ss, vfu_pci_hdr_cc_t cc,
-                         vfu_pci_type_t pci_type,
-                         int revision __attribute__((unused)));
-
-/* FIXME does it have to be packed as well? */
-typedef union {
-    struct msicap   msi;
-    struct msixcap  msix;
-    struct pmcap    pm;
-    struct pxcap    px;
-    struct vsc      vsc;
-} vfu_cap_t;
-
-//TODO: Support variable size capabilities.
-
-/**
- * Setup PCI capabilities.
- *
- * @vfu_ctx: the libvfio-user context
- * @caps: array of (vfu_cap_t *)
- * @nr_caps: number of elements in @caps
- */
-int
-vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
-
-#define VFU_REGION_FLAG_READ    (1 << 0)
-#define VFU_REGION_FLAG_WRITE   (1 << 1)
-#define VFU_REGION_FLAG_MMAP    (1 << 2)    // TODO: how this relates to IO bar?
-#define VFU_REGION_FLAG_RW      (VFU_REGION_FLAG_READ | VFU_REGION_FLAG_WRITE)
-#define VFU_REGION_FLAG_MEM     (1 << 3)    // if unset, bar is IO
-
-/**
- * Prototype for region access callback. When a region is accessed, libvfio-user
- * calls the previously registered callback with the following arguments:
- *
- * @pvt: private data originally passed by vfu_create_ctx()
- * @buf: buffer containing the data to be written or data to be read into
- * @count: number of bytes being read or written
- * @offset: byte offset within the region
- * @is_write: whether or not this is a write
- *
- * @returns the number of bytes read or written, or a negative integer on error
- */
-typedef ssize_t (vfu_region_access_cb_t) (void *pvt, char *buf, size_t count,
-                                          loff_t offset, bool is_write);
-
-/* PCI regions */
-enum {
-    VFU_PCI_DEV_BAR0_REGION_IDX,
-    VFU_PCI_DEV_BAR1_REGION_IDX,
-    VFU_PCI_DEV_BAR2_REGION_IDX,
-    VFU_PCI_DEV_BAR3_REGION_IDX,
-    VFU_PCI_DEV_BAR4_REGION_IDX,
-    VFU_PCI_DEV_BAR5_REGION_IDX,
-    VFU_PCI_DEV_ROM_REGION_IDX,
-    VFU_PCI_DEV_CFG_REGION_IDX,
-    VFU_PCI_DEV_VGA_REGION_IDX,
-    VFU_PCI_DEV_NUM_REGIONS,
-};
-
-/**
- * Set up a region.
- *
- * If this is the PCI configuration space, the @size argument is ignored. The
- * size of the region is determined by the PCI type (set when the libvfio-user
- * context is created). Accesses to the PCI configuration space header and the
- * PCI capabilities are handled internally; the user supplied callback is not
- * called.
- *
- * @vfu_ctx: the libvfio-user context
- * @region_idx: region index
- * @size: size of the region
- * @region_access: callback function to access region
- * @flags: region  flags
- * @mmap_areas: array of memory mappable areas
- * @nr_mmap_areas: size of mmap_areas
- * @map: callback function to map region
- *
- * @returns 0 on success, -1 on error, Sets errno.
- */
-int
-vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
-                 vfu_region_access_cb_t *region_access, int flags,
-                 struct iovec *mmap_areas, uint32_t nr_mmap_areas,
-                 vfu_map_region_cb_t *map);
-
-/*
- * Callback function that is called when the guest resets the device.
- * @pvt: private pointer
- */
-typedef int (vfu_reset_cb_t) (void *pvt);
-
-/*
- * Function that is called when the guest maps a DMA region. Optional.
- * @pvt: private pointer
- * @iova: iova address
- * @len: length
- */
-typedef void (vfu_map_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
-
-/*
- * Function that is called when the guest unmaps a DMA region. The device
- * must release all references to that region before the callback returns.
- * This is required if you want to be able to access guest memory.
- * @pvt: private pointer
- * @iova: iova address
- * @len: length
- */
-typedef int (vfu_unmap_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
-
-/**
- * Setup device reset callback.
- * @vfu_ctx: the libvfio-user context
- * @reset: device reset callback (optional)
- */
-int
-vfu_setup_device_reset_cb(vfu_ctx_t *vfu_ctx, vfu_reset_cb_t *reset);
-
-/**
- * Setup device DMA map/unmap callbacks.
- * @vfu_ctx: the libvfio-user context
- * @map_dma: DMA region map callback (optional)
- * @unmap_dma: DMA region unmap callback (optional)
- */
-
-int
-vfu_setup_device_dma_cb(vfu_ctx_t *vfu_ctx, vfu_map_dma_cb_t *map_dma,
-                        vfu_unmap_dma_cb_t *unmap_dma);
-
-enum vfu_dev_irq_type {
-    VFU_DEV_INTX_IRQ,
-    VFU_DEV_MSI_IRQ,
-    VFU_DEV_MSIX_IRQ,
-    VFU_DEV_ERR_IRQ,
-    VFU_DEV_REQ_IRQ,
-    VFU_DEV_NUM_IRQS
-};
-
-/**
- * Setup device IRQ counts.
- * @vfu_ctx: the libvfio-user context
- * @type: IRQ type (VFU_DEV_INTX_IRQ ... VFU_DEV_REQ_IRQ)
- * @count: number of irqs
- */
-int
-vfu_setup_device_nr_irqs(vfu_ctx_t *vfu_ctx, enum vfu_dev_irq_type type,
-                         uint32_t count);
-
 //TODO: Re-visit once migration support is done.
 /**
  * Enable support for device migration.
@@ -417,31 +393,6 @@ vfu_setup_device_nr_irqs(vfu_ctx_t *vfu_ctx, enum vfu_dev_irq_type type,
  */
 int
 vfu_setup_device_migration(vfu_ctx_t *vfu_ctx, vfu_migration_t *migration);
-
-/**
- * Destroys libvfio-user context.
- *
- * @vfu_ctx: the libvfio-user context to destroy
- */
-void
-vfu_destroy_ctx(vfu_ctx_t *vfu_ctx);
-
-/**
- * Polls the vfu_ctx and processes the command recieved from client.
- * - Blocking vfu_ctx:
- *   Blocks until new request is received from client and continues processing
- *   the requests. Exits only in case of error or if the client disconnects.
- * - Non-blocking vfu_ctx(LIBVFIO_USER_FLAG_ATTACH_NB):
- *   Processes one request from client if it's available, otherwise it
- *   immediatelly returns and the caller is responsible for periodically
- *   calling again.
- *
- * @vfu_ctx: The libvfio-user context to poll
- *
- * @returns 0 on success, -errno on failure.
- */
-int
-vfu_run_ctx(vfu_ctx_t *vfu_ctx);
 
 /**
  * Triggers an interrupt.
@@ -472,15 +423,6 @@ vfu_irq_trigger(vfu_ctx_t *vfu_ctx, uint32_t subindex);
 
 int
 vfu_irq_message(vfu_ctx_t *vfu_ctx, uint32_t subindex);
-
-/* Helper functions */
-
-/**
- * Converts a guest physical address to a dma_sg_t element which can
- * be later passed on to vfu_map_sg to memory map the GPA. It is the caller's
- * responsibility to unmap it by calling vfu_unmap_sg.
- *
- */
 
 /**
  * Takes a guest physical address and returns a list of scatter/gather entries
@@ -576,27 +518,83 @@ int
 vfu_dma_write(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data);
 
 /*
- * Finalizes the device making it ready for vfu_attach_ctx(). This function is
- * mandatory to be called before vfu_attach_ctx().
- * @vfu_ctx: the libvfio-user context
+ * Supported PCI regions.
  *
- * @returns: 0 on success, -1 on error. Sets errno.
+ * FIXME: update with CFG behaviour etc.
+ */
+enum {
+    VFU_PCI_DEV_BAR0_REGION_IDX,
+    VFU_PCI_DEV_BAR1_REGION_IDX,
+    VFU_PCI_DEV_BAR2_REGION_IDX,
+    VFU_PCI_DEV_BAR3_REGION_IDX,
+    VFU_PCI_DEV_BAR4_REGION_IDX,
+    VFU_PCI_DEV_BAR5_REGION_IDX,
+    VFU_PCI_DEV_ROM_REGION_IDX,
+    VFU_PCI_DEV_CFG_REGION_IDX,
+    VFU_PCI_DEV_VGA_REGION_IDX,
+    VFU_PCI_DEV_NUM_REGIONS,
+};
+
+typedef enum {
+    VFU_PCI_TYPE_CONVENTIONAL,
+    VFU_PCI_TYPE_PCI_X_1,
+    VFU_PCI_TYPE_PCI_X_2,
+    VFU_PCI_TYPE_EXPRESS
+} vfu_pci_type_t;
+
+/**
+ * Setup PCI configuration space header data. This function must be called only
+ * once per libvfio-user context.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @id: Device and vendor ID
+ * @ss: Subsystem vendor and device ID
+ * @cc: Class code
+ * @pci_type: PCI type (convention PCI, PCI-X mode 1, PCI-X mode2, PCI-Express)
+ * @revision: PCI/PCI-X/PCIe revision
+ *
+ * @returns 0 on success, -1 on failure and sets errno.
+ * TODO: Check other PCI header registers suitable to be filled by device.
+ *       Or should we pass whole vfu_pci_hdr_t to be filled by user.
+
  */
 int
-vfu_realize_ctx(vfu_ctx_t *vfu_ctx);
+vfu_pci_setup_config_hdr(vfu_ctx_t *vfu_ctx, vfu_pci_hdr_id_t id,
+                         vfu_pci_hdr_ss_t ss, vfu_pci_hdr_cc_t cc,
+                         vfu_pci_type_t pci_type,
+                         int revision __attribute__((unused)));
 
 /*
- * Attempts to attach to the transport. Attach is mandatory before
- * vfu_run_ctx() and is non blocking if context is created
- * with LIBVFIO_USER_FLAG_ATTACH_NB flag.
- * Returns client's file descriptor on success and -1 on error. If errno is
- * set to EAGAIN or EWOULDBLOCK then the transport is not ready to attach to and
- * the operation must be retried.
+ * Returns a pointer to the PCI configuration space.
+ *
+ * PCI config space consists of an initial 64-byte vfu_pci_hdr_t, plus
+ * additional space, either containing capabilities, or device-specific
+ * configuration.  Standard config space is 256 bytes; extended config space is
+ * 4096 bytes.
+ */
+vfu_pci_config_space_t *
+vfu_pci_get_config_space(vfu_ctx_t *vfu_ctx);
+
+/* FIXME does it have to be packed as well? */
+typedef union {
+    struct msicap   msi;
+    struct msixcap  msix;
+    struct pmcap    pm;
+    struct pxcap    px;
+    struct vsc      vsc;
+} vfu_cap_t;
+
+//TODO: Support variable size capabilities.
+
+/**
+ * Setup PCI capabilities.
  *
  * @vfu_ctx: the libvfio-user context
+ * @caps: array of (vfu_cap_t *)
+ * @nr_caps: number of elements in @caps
  */
 int
-vfu_attach_ctx(vfu_ctx_t *vfu_ctx);
+vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
 
 /* FIXME this function is broken as the can be multiples capabilities with the
  * same ID, e.g. the vendor-specific capability.
@@ -605,9 +603,6 @@ vfu_attach_ctx(vfu_ctx_t *vfu_ctx);
  */
 uint8_t *
 vfu_ctx_get_cap(vfu_ctx_t *vfu_ctx, uint8_t id);
-
-void
-vfu_log(vfu_ctx_t *vfu_ctx, int level, const char *fmt, ...);
 
 #ifdef __cplusplus
 }

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -40,7 +40,8 @@
 #include "libvfio-user.h"
 #include "cap.h"
 
-#define VFU_MAX_CAPS 48
+#define VFU_MAX_CAPS \
+    ((PCI_CFG_SPACE_SIZE - PCI_STD_HEADER_SIZEOF) / PCI_CAP_SIZEOF)
 
 /*
  * PCI capabilities are stored after the the PCI configuration space header

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -40,6 +40,8 @@
 #include "libvfio-user.h"
 #include "cap.h"
 
+#define VFU_MAX_CAPS 48
+
 /*
  * PCI capabilities are stored after the the PCI configuration space header
  * (vfu_ctx->config_space), as they would in an actual PCI device. We also


### PR DESCRIPTION

This is almost entirely re-ordering: first the basic lifecycle things, then
vfu_setup_*() group, then handlers and helpers, and finally PCI handling.

Signed-off-by: John Levon <john.levon@nutanix.com>