### PR TITLE
PCI config setup API 

### DIFF
--- a/samples/client.c
+++ b/samples/client.c
@@ -983,7 +983,7 @@ int main(int argc, char *argv[])
      */
     negotiate(sock, &server_max_fds, &pgsize);
 
-    /* try to access a bogus region, we should het an error */
+    /* try to access a bogus region, we should get an error */
     ret = access_region(sock, 0xdeadbeef, false, 0, &ret, sizeof ret);
     if (ret != -EINVAL) {
         errx(EXIT_FAILURE,
@@ -1006,10 +1006,11 @@ int main(int argc, char *argv[])
         errx(EXIT_FAILURE, "failed to read PCI configuration space: %s\n",
              strerror(-ret));
     }
-    assert(config_space.id.raw == 0xdeadbeef);
-    assert(config_space.ss.raw == 0xcafebabe);
-    assert(config_space.cc.pi == 0xab && config_space.cc.scc == 0xcd
-           && config_space.cc.bcc == 0xef);
+
+    assert(config_space.id.vid == 0xdead);
+    assert(config_space.id.did == 0xbeef);
+    assert(config_space.ss.vid == 0xcafe);
+    assert(config_space.ss.sid == 0xbabe);
 
     /* XXX VFIO_USER_DEVICE_RESET */
     send_device_reset(sock);

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -75,9 +75,6 @@ main(int argc, char *argv[])
     char opt;
     struct sigaction act = { .sa_handler = _sa_handler };
     vfu_ctx_t *vfu_ctx;
-    vfu_pci_hdr_id_t id = { .vid = 0x494F, .did = 0x0DC8 };
-    vfu_pci_hdr_ss_t ss = { .vid = 0x0, .sid = 0x0 };
-    vfu_pci_hdr_cc_t cc = { { 0 } };
 
     while ((opt = getopt(argc, argv, "v")) != -1) {
         switch (opt) {
@@ -114,12 +111,13 @@ main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to setup log");
     }
 
-    ret = vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc, 
-                                   VFU_PCI_TYPE_CONVENTIONAL, 0);
+    ret = vfu_pci_init(vfu_ctx, VFU_PCI_TYPE_CONVENTIONAL,
+                       PCI_HEADER_TYPE_NORMAL, 0);
     if (ret < 0) {
-        fprintf(stderr, "failed to setup pci header\n");
-        goto out;
+        err(EXIT_FAILURE, "vfu_pci_init() failed");
     }
+
+    vfu_pci_set_id(vfu_ctx, 0x494f, 0x0dc8, 0x0, 0x0);
 
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR2_REGION_IDX, 0x100,
                            &bar2_access, VFU_REGION_FLAG_RW, NULL, 0, -1);

--- a/samples/lspci.c
+++ b/samples/lspci.c
@@ -42,9 +42,6 @@ int main(void)
     int i, j;
     char *buf;
     const int bytes_per_line = 0x10;
-    vfu_pci_hdr_id_t id = { 0 };
-    vfu_pci_hdr_ss_t ss = { 0 };
-    vfu_pci_hdr_cc_t cc = { { 0 } };
     vfu_cap_t pm = { .pm = { .hdr.id = PCI_CAP_ID_PM, .pmcs.nsfrst = 0x1 } };
     vfu_cap_t *vsc = alloca(sizeof(*vsc) + 0xd);
     vfu_cap_t *caps[2] = { &pm, vsc };
@@ -54,8 +51,9 @@ int main(void)
     if (vfu_ctx == NULL) {
         err(EXIT_FAILURE, "failed to create libvfio-user context");
     }
-    if (vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc, VFU_PCI_TYPE_CONVENTIONAL, 0) < 0) {
-        err(EXIT_FAILURE, "failed to setup PCI configuration space header");
+    if (vfu_pci_init(vfu_ctx, VFU_PCI_TYPE_CONVENTIONAL,
+                     PCI_HEADER_TYPE_NORMAL, 0) < 0) {
+        err(EXIT_FAILURE, "vfu_pci_init() failed");
     }
     vsc->vsc.hdr.id = PCI_CAP_ID_VNDR;
     vsc->vsc.size = 0x10;

--- a/samples/null.c
+++ b/samples/null.c
@@ -81,10 +81,6 @@ int main(int argc, char **argv)
 {
     int ret;
     pthread_t thread;
-    vfu_pci_hdr_id_t id = { 0 };
-    vfu_pci_hdr_ss_t ss = { 0 };
-    vfu_pci_hdr_cc_t cc = { { 0 } };
-
 
     if (argc != 2) {
         errx(EXIT_FAILURE, "missing vfio-user socket path");
@@ -101,8 +97,10 @@ int main(int argc, char **argv)
         err(EXIT_FAILURE, "failed to setup log");
     }
 
-    ret = vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc,
-                                   VFU_PCI_TYPE_CONVENTIONAL, 0);
+    if (vfu_pci_init(vfu_ctx, VFU_PCI_TYPE_CONVENTIONAL,
+                     PCI_HEADER_TYPE_NORMAL, 0) < 0) {
+        err(EXIT_FAILURE, "vfu_pci_init() failed");
+    }
 
     ret = pthread_create(&thread, NULL, null_drive, vfu_ctx);
     if (ret != 0) {

--- a/samples/server.c
+++ b/samples/server.c
@@ -375,9 +375,6 @@ int main(int argc, char *argv[])
         }
     };
     vfu_ctx_t *vfu_ctx;
-    vfu_pci_hdr_id_t id = {.raw = 0xdeadbeef};
-    vfu_pci_hdr_ss_t ss = {.raw = 0xcafebabe};
-    vfu_pci_hdr_cc_t cc = {.pi = 0xab, .scc = 0xcd, .bcc = 0xef};
     FILE *fp;
 
     while ((opt = getopt(argc, argv, "v")) != -1) {
@@ -416,11 +413,13 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to setup log");
     }
 
-    ret = vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc,
-                                   VFU_PCI_TYPE_CONVENTIONAL, 0);
+    ret = vfu_pci_init(vfu_ctx, VFU_PCI_TYPE_CONVENTIONAL,
+                       PCI_HEADER_TYPE_NORMAL, 0);
     if (ret < 0) {
-        err(EXIT_FAILURE, "failed to setup PCI header");
+        err(EXIT_FAILURE, "vfu_pci_init() failed") ;
     }
+
+    vfu_pci_set_id(vfu_ctx, 0xdead, 0xbeef, 0xcafe, 0xbabe);
 
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX, sizeof(time_t),
                            &bar0_access, VFU_REGION_FLAG_RW, NULL, 0, -1);

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -516,9 +516,6 @@ static void
 test_vfu_ctx_create(void **state __attribute__((unused)))
 {
     vfu_ctx_t *vfu_ctx = NULL;
-    vfu_pci_hdr_id_t id = { 0 };
-    vfu_pci_hdr_ss_t ss = { 0 };
-    vfu_pci_hdr_cc_t cc = { { 0 } };
     vfu_cap_t pm = {.pm = {.hdr.id = PCI_CAP_ID_PM}};
     vfu_cap_t *caps[] = { &pm };
 
@@ -527,9 +524,8 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     assert_non_null(vfu_ctx);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_ERR_IRQ]);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_REQ_IRQ]);
-    assert_int_equal(0,
-                     vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc,
-                                              VFU_PCI_TYPE_CONVENTIONAL, 0));
+    assert_int_equal(0, vfu_pci_init(vfu_ctx, VFU_PCI_TYPE_CONVENTIONAL,
+                        PCI_HEADER_TYPE_NORMAL, 0));
     assert_int_equal(0, vfu_pci_setup_caps(vfu_ctx, caps, 1));
     assert_int_equal(0, vfu_realize_ctx(vfu_ctx));
 }


### PR DESCRIPTION
Split up vfu_pci_setup_config_hdr(): individual "helpers" like vfu_pci_set_id()
are much simpler to use than making the user specify the values in
header-formatted structs; and this way if we want to add additional helpers, we
won't need to modify the existing functions.

Signed-off-by: John Levon <john.levon@nutanix.com>