### PR TITLE
re-work capability-locating API

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -623,53 +623,30 @@ vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
  * Find the offset within config space of a given capability (if there are
  * multiple possible matches, use vfu_pci_find_next_capability()).
  *
- * Returns 0 if no such capability was found.
+ * Returns 0 if no such capability was found, with errno set.
  *
  * @vfu_ctx: the libvfio-user context
- * @id: capability id
+ * @extended whether capability is an extended one or not
+ * @id: capability id (PCI_CAP_ID_* or PCI_EXT_CAP_ID *)
  */
 size_t
-vfu_pci_find_capability(vfu_ctx_t *vfu_ctx, int cap_id);
+vfu_pci_find_capability(vfu_ctx_t *vfu_ctx, bool extended, int cap_id);
 
 /**
  * Find the offset within config space of the given capability, starting from
  * @pos.  This can be used to iterate through multiple capabilities with the
  * same ID.
  *
- * Returns 0 if no more matching capabilities were found.
+ * Returns 0 if no more matching capabilities were found, with errno set.
  *
  * @vfu_ctx: the libvfio-user context
  * @pos: offset within config space to start looking
- * @id: capability id
+ * @extended whether capability is an extended one or not
+ * @id: capability id (PCI_CAP_ID_*)
  */
 size_t
-vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, size_t pos, int cap_id);
-
-/**
- * Find the offset within config space of a given extended capability (if there
- * are multiple possible matches, use vfu_pci_find_next_ext_capability()).
- *
- * Returns 0 if no such capability was found.
- *
- * @vfu_ctx: the libvfio-user context
- * @id: capability id (PCI_EXT_CAP_ID_*)
- */
-size_t
-vfu_pci_find_ext_capability(vfu_ctx_t *vfu_ctx, int cap_id);
-
-/**
- * Find the offset within config space of the given extended capability,
- * starting from @pos.  This can be used to iterate through multiple
- * extended capabilities with the same ID.
- *
- * Returns 0 if no more matching extended capabilities were found.
- *
- * @vfu_ctx: the libvfio-user context
- * @pos: offset within config space to start looking
- * @id: capability id (PCI_EXT_CAP_ID_*)
- */
-size_t
-vfu_pci_find_next_ext_capability(vfu_ctx_t *vfu_ctx, size_t pos, int cap_id);
+vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, bool extended,
+                             size_t pos, int cap_id);
 
 #ifdef __cplusplus
 }

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -619,13 +619,57 @@ typedef union {
 int
 vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
 
-/* FIXME this function is broken as the can be multiples capabilities with the
- * same ID, e.g. the vendor-specific capability.
+/**
+ * Find the offset within config space of a given capability (if there are
+ * multiple possible matches, use vfu_pci_find_next_capability()).
+ *
+ * Returns 0 if no such capability was found.
+ *
  * @vfu_ctx: the libvfio-user context
  * @id: capability id
  */
-uint8_t *
-vfu_ctx_get_cap(vfu_ctx_t *vfu_ctx, uint8_t id);
+size_t
+vfu_pci_find_capability(vfu_ctx_t *vfu_ctx, int cap_id);
+
+/**
+ * Find the offset within config space of the given capability, starting from
+ * @pos.  This can be used to iterate through multiple capabilities with the
+ * same ID.
+ *
+ * Returns 0 if no more matching capabilities were found.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @pos: offset within config space to start looking
+ * @id: capability id
+ */
+size_t
+vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, size_t pos, int cap_id);
+
+/**
+ * Find the offset within config space of a given extended capability (if there
+ * are multiple possible matches, use vfu_pci_find_next_ext_capability()).
+ *
+ * Returns 0 if no such capability was found.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @id: capability id (PCI_EXT_CAP_ID_*)
+ */
+size_t
+vfu_pci_find_ext_capability(vfu_ctx_t *vfu_ctx, int cap_id);
+
+/**
+ * Find the offset within config space of the given extended capability,
+ * starting from @pos.  This can be used to iterate through multiple
+ * extended capabilities with the same ID.
+ *
+ * Returns 0 if no more matching extended capabilities were found.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @pos: offset within config space to start looking
+ * @id: capability id (PCI_EXT_CAP_ID_*)
+ */
+size_t
+vfu_pci_find_next_ext_capability(vfu_ctx_t *vfu_ctx, size_t pos, int cap_id);
 
 #ifdef __cplusplus
 }

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -510,24 +510,16 @@ vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, bool extended,
         }
 
         if (config_space->raw[offset + PCI_CAP_LIST_ID] == cap_id) {
-            break;
+            return offset;
         }
 
         offset = config_space->raw[offset + PCI_CAP_LIST_NEXT];
 
         if (offset == 0) {
             errno = ENOENT;
-            break;
+            return 0;
         }
     }
-
-    /* Sanity check. */
-    if (offset + PCI_CAP_LIST_NEXT >= space_size) {
-        errno = EINVAL;
-        return 0;
-    }
-
-    return offset;
 }
 
 size_t

--- a/lib/cap.c
+++ b/lib/cap.c
@@ -484,7 +484,7 @@ vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, bool extended,
         return 0;
     }
 
-    if (offset >= space_size) {
+    if (offset + PCI_CAP_LIST_NEXT >= space_size) {
         errno = EINVAL;
         return 0;
     }
@@ -503,6 +503,12 @@ vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, bool extended,
     }
 
     for (;;) {
+        /* Sanity check. */
+        if (offset + PCI_CAP_LIST_NEXT >= space_size) {
+            errno = EINVAL;
+            return 0;
+        }
+
         if (config_space->raw[offset + PCI_CAP_LIST_ID] == cap_id) {
             break;
         }
@@ -513,6 +519,12 @@ vfu_pci_find_next_capability(vfu_ctx_t *vfu_ctx, bool extended,
             errno = ENOENT;
             break;
         }
+    }
+
+    /* Sanity check. */
+    if (offset + PCI_CAP_LIST_NEXT >= space_size) {
+        errno = EINVAL;
+        return 0;
     }
 
     return offset;

--- a/lib/cap.h
+++ b/lib/cap.h
@@ -54,9 +54,6 @@ ssize_t
 cap_maybe_access(vfu_ctx_t *vfu_ctx, struct caps *caps, char *buf, size_t count,
                  loff_t offset);
 
-uint8_t *
-cap_find_by_id(vfu_ctx_t *vfu_ctx, uint8_t id);
-
 #endif /* LIB_VFIO_USER_CAP_H */
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1530,14 +1530,6 @@ vfu_unmap_sg(vfu_ctx_t *vfu_ctx, const dma_sg_t *sg, struct iovec *iov, int cnt)
     return dma_unmap_sg(vfu_ctx->dma, sg, iov, cnt);
 }
 
-uint8_t *
-vfu_ctx_get_cap(vfu_ctx_t *vfu_ctx, uint8_t id)
-{
-    assert(vfu_ctx != NULL);
-
-    return cap_find_by_id(vfu_ctx, id);
-}
-
 int
 vfu_dma_read(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data)
 {

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -611,6 +611,13 @@ test_pci_caps(void **state __attribute__((unused)))
     assert_int_equal(0, offset);
     assert_int_equal(EINVAL, errno);
 
+    offset = vfu_pci_find_next_capability(&vfu_ctx, false,
+                                          PCI_STD_HEADER_SIZEOF +
+                                          PCI_PM_SIZEOF + 1,
+                                          PCI_CAP_ID_VNDR);
+    assert_int_equal(0, offset);
+    assert_int_equal(ENOENT, errno);
+
     /* check writing PMCS */
     assert_int_equal(0,
         cap_maybe_access(&vfu_ctx, caps, (char*)&pmcap.pmcs,

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -600,6 +600,16 @@ test_pci_caps(void **state __attribute__((unused)))
                                           PCI_CAP_ID_VNDR);
     assert_int_equal(0, offset);
 
+    /* check for invalid offsets */
+    offset = vfu_pci_find_next_capability(&vfu_ctx, false, 8192, PCI_CAP_ID_PM);
+    assert_int_equal(0, offset);
+    assert_int_equal(EINVAL, errno);
+    offset = vfu_pci_find_next_capability(&vfu_ctx, false, 256, PCI_CAP_ID_PM);
+    assert_int_equal(0, offset);
+    assert_int_equal(EINVAL, errno);
+    offset = vfu_pci_find_next_capability(&vfu_ctx, false, 255, PCI_CAP_ID_PM);
+    assert_int_equal(0, offset);
+    assert_int_equal(EINVAL, errno);
 
     /* check writing PMCS */
     assert_int_equal(0,


### PR DESCRIPTION
Explicitly mimic the Linux kernel API: the searching functions return an offset
into configuration space.  Just like a driver, libvfio-user devices can then
look into config space via vfu_pci_get_config_space to read the capability as
needed. In general, the driver itself will know exactly what the size and shape
of the capability is, so this seems like a low-friction, and familiar to driver
writers, API.

Signed-off-by: John Levon <john.levon@nutanix.com>