### PR TITLE
enable ERR and REQ IRQs by default

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -88,7 +88,8 @@ typedef enum {
 } vfu_dev_type_t;
 
 /**
- * Creates libvfio-user context.
+ * Creates libvfio-user context. By default one ERR and one REQ IRQs are
+ * initialized, this can be overridden with vfu_setup_device_nr_irqs.
  *
  * @trans: transport type
  * @path: path to socket file.

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1349,6 +1349,15 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
         goto out;
     }
 
+    if (vfu_setup_device_nr_irqs(vfu_ctx, VFU_DEV_ERR_IRQ, 1) == -1) {
+        err = -errno;
+        goto out;
+    }
+    if (vfu_setup_device_nr_irqs(vfu_ctx, VFU_DEV_REQ_IRQ, 1) == -1) {
+        err = -errno;
+        goto out;
+    }
+
     if (vfu_ctx->trans->init != NULL) {
         err = vfu_ctx->trans->init(vfu_ctx);
         if (err < 0) {

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -521,6 +521,8 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     vfu_ctx = vfu_create_ctx(VFU_TRANS_SOCK, "", LIBVFIO_USER_FLAG_ATTACH_NB,
                              NULL, VFU_DEV_TYPE_PCI);
     assert_non_null(vfu_ctx);
+    assert_int_equal(1, vfu_ctx->irq_type[VFU_DEV_ERR_IRQ]);
+    assert_int_equal(1, vfu_ctx->irq_type[VFU_DEV_REQ_IRQ]);
     assert_int_equal(0,
                      vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc,
                                               VFU_PCI_TYPE_CONVENTIONAL, 0));

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -521,8 +521,8 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     vfu_ctx = vfu_create_ctx(VFU_TRANS_SOCK, "", LIBVFIO_USER_FLAG_ATTACH_NB,
                              NULL, VFU_DEV_TYPE_PCI);
     assert_non_null(vfu_ctx);
-    assert_int_equal(1, vfu_ctx->irq_type[VFU_DEV_ERR_IRQ]);
-    assert_int_equal(1, vfu_ctx->irq_type[VFU_DEV_REQ_IRQ]);
+    assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_ERR_IRQ]);
+    assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_REQ_IRQ]);
     assert_int_equal(0,
                      vfu_pci_setup_config_hdr(vfu_ctx, id, ss, cc,
                                               VFU_PCI_TYPE_CONVENTIONAL, 0));


### PR DESCRIPTION
VFIO in QEMU seems to expect this

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>