### PR TITLE
Reorg vfu_create_ctx() and also create dma_controller

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -287,7 +287,9 @@ typedef void (vfu_map_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
 typedef int (vfu_unmap_dma_cb_t) (void *pvt, uint64_t iova, uint64_t len);
 
 /**
- * Setup device DMA map/unmap callbacks.
+ * Setup device DMA map/unmap callbacks. This will also enable bookkeeping of
+ * DMA regions received from client, otherwise they will be just acknowledged.
+ *
  * @vfu_ctx: the libvfio-user context
  * @map_dma: DMA region map callback (optional)
  * @unmap_dma: DMA region unmap callback (optional)

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1334,7 +1334,7 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
 
     vfu_ctx->uuid = strdup(path);
     if (vfu_ctx->uuid == NULL) {
-        err = errno;
+        err = -errno;
         goto err_out;
     }
 
@@ -1365,13 +1365,6 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
             goto err_out;
         }
         vfu_ctx->fd = err;
-    }
-
-    // Create the internal DMA controller.
-    vfu_ctx->dma = dma_controller_create(vfu_ctx, VFU_DMA_REGIONS);
-    if (vfu_ctx->dma == NULL) {
-        err = -ENOMEM;
-        goto err_out;
     }
 
     return vfu_ctx;
@@ -1579,7 +1572,12 @@ vfu_setup_device_dma_cb(vfu_ctx_t *vfu_ctx, vfu_map_dma_cb_t *map_dma,
 {
 
     assert(vfu_ctx != NULL);
-    assert(vfu_ctx->dma != NULL);
+
+    // Create the internal DMA controller.
+    vfu_ctx->dma = dma_controller_create(vfu_ctx, VFU_DMA_REGIONS);
+    if (vfu_ctx->dma == NULL) {
+        return ERROR(ENOMEM);
+    }
 
     vfu_ctx->map_dma = map_dma;
     vfu_ctx->unmap_dma = unmap_dma;

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -525,7 +525,6 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     vfu_ctx = vfu_create_ctx(VFU_TRANS_SOCK, "", LIBVFIO_USER_FLAG_ATTACH_NB,
                              NULL, VFU_DEV_TYPE_PCI);
     assert_non_null(vfu_ctx);
-    assert_non_null(vfu_ctx->dma);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_ERR_IRQ]);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_REQ_IRQ]);
     assert_int_equal(0,
@@ -681,6 +680,15 @@ test_dma_map_sg(void **state __attribute__((unused)))
 
 }
 
+static void
+test_vfu_setup_device_dma_cb(void **state __attribute__((unused)))
+{
+    vfu_ctx_t vfu_ctx = { 0 };
+
+    assert_int_equal(0, vfu_setup_device_dma_cb(&vfu_ctx, NULL, NULL));
+    assert_non_null(vfu_ctx.dma);
+}
+
 /*
  * FIXME we shouldn't have to specify a setup function explicitly for each unit
  * test, cmocka should provide that. E.g. cmocka_run_group_tests enables us to
@@ -713,7 +721,8 @@ int main(void)
         cmocka_unit_test_setup(test_get_region_info, setup),
         cmocka_unit_test_setup(test_setup_sparse_region, setup),
         cmocka_unit_test_setup(test_dma_map_return_value, setup),
-        cmocka_unit_test_setup(test_dma_map_sg, setup)
+        cmocka_unit_test_setup(test_dma_map_sg, setup),
+        cmocka_unit_test_setup(test_vfu_setup_device_dma_cb, setup)
     };
 
     return cmocka_run_group_tests(tests, NULL, NULL);

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -525,6 +525,7 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     vfu_ctx = vfu_create_ctx(VFU_TRANS_SOCK, "", LIBVFIO_USER_FLAG_ATTACH_NB,
                              NULL, VFU_DEV_TYPE_PCI);
     assert_non_null(vfu_ctx);
+    assert_non_null(vfu_ctx->dma);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_ERR_IRQ]);
     assert_int_equal(1, vfu_ctx->irq_count[VFU_DEV_REQ_IRQ]);
     assert_int_equal(0,


### PR DESCRIPTION
dma_controller_add_region() adds dma_region only if
vfu_ctx->dma is created.

vfu_setup_device_dma_cb() should only set callbacks.

Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>