### PR TITLE
 re-work access handling 

### DIFF
--- a/lib/cap.c
+++ b/lib/cap.c
@@ -83,9 +83,7 @@ cap_is_accessed(struct cap *caps, int nr_caps, size_t count, loff_t offset)
         }
 
         /*
-         * FIXME write starts before capabilities but extends into them. I don't
-         * think that the while loop in vfu_access will allow this in the first
-         * place.
+         * FIXME write starts before capabilities but extends into them.
          */
         assert(false);
     } else if (offset > caps[nr_caps - 1].end) {

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -165,10 +165,11 @@ dev_get_caps(vfu_ctx_t *vfu_ctx, vfu_reg_info_t *vfu_reg, bool is_migr_reg,
     return 0;
 }
 
-#ifdef VFU_VERBOSE_LOGGING
-void
-dump_buffer(const char *prefix, const char *buf, uint32_t count)
+inline void
+dump_buffer(const char *prefix UNUSED, const char *buf UNUSED,
+            uint32_t count UNUSED)
 {
+#ifdef VFU_VERBOSE_LOGGING
     int i;
     const size_t bytes_per_line = 0x8;
 
@@ -188,15 +189,161 @@ dump_buffer(const char *prefix, const char *buf, uint32_t count)
     if (i % bytes_per_line != 0) {
         fprintf(stderr, "\n");
     }
-}
-#else
-#define dump_buffer(prefix, buf, count)
 #endif
+}
 
 static bool
 is_migr_reg(vfu_ctx_t *vfu_ctx, int index)
 {
     return &vfu_ctx->reg_info[index] == vfu_ctx->migr_reg;
+}
+
+static ssize_t
+region_access(vfu_ctx_t *vfu_ctx, size_t region_index,
+              bool is_write, char *buf, uint64_t offset, size_t count)
+{
+    ssize_t ret;
+
+    assert(vfu_ctx != NULL);
+    assert(buf != NULL);
+
+    vfu_log(vfu_ctx, LOG_DEBUG, "%s %zu %#lx-%#lx", is_write ? "W" : "R",
+            region_index, offset, offset + count);
+
+    if (is_write) {
+        dump_buffer("buffer write", buf, count);
+    }
+
+    if (region_index == VFU_PCI_DEV_CFG_REGION_IDX) {
+        ret = pci_config_space_access(vfu_ctx, buf, count, offset, is_write);
+    } else if (is_migr_reg(vfu_ctx, region_index)) {
+        ret = migration_region_access(vfu_ctx, buf, count, offset, is_write);
+    } else {
+        vfu_region_access_cb_t *cb = vfu_ctx->reg_info[region_index].fn;
+
+        if (cb == NULL) {
+            vfu_log(vfu_ctx, LOG_ERR, "no callback for region %d",
+                    region_index);
+            return -EINVAL;
+        }
+
+        ret = cb(vfu_ctx, buf, count, offset, is_write);
+    }
+
+    if (!is_write && (size_t)ret == count) {
+        dump_buffer("buffer read", buf, count);
+    }
+
+    return ret;
+}
+
+static bool
+valid_region_access(vfu_ctx_t *vfu_ctx, size_t size, uint16_t cmd,
+                    struct vfio_user_region_access *ra)
+{
+    size_t index;
+
+    assert(ra != NULL);
+
+    if (size < sizeof (*ra)) {
+        vfu_log(vfu_ctx, LOG_ERR, "message size too small (%d)", size);
+        return false;
+    }
+
+    if (cmd == VFIO_USER_REGION_WRITE && size - sizeof (*ra) != ra->count) {
+        vfu_log(vfu_ctx, LOG_ERR, "region write count too small: "
+                "expected %lu, got %u", size - sizeof (*ra), ra->count);
+        return false;
+    }
+
+    if (ra->count == 0) {
+        vfu_log(vfu_ctx, LOG_ERR, "bad region access count of 0");
+        return false;
+    }
+
+    index = ra->region;
+
+    if (index >= vfu_ctx->nr_regions) {
+        vfu_log(vfu_ctx, LOG_ERR, "bad region index %u", index);
+        return false;
+    }
+
+    // FIXME: need to audit later for wraparound
+    if (ra->offset + ra->count > vfu_ctx->reg_info[index].size) {
+        vfu_log(vfu_ctx, LOG_ERR, "out of bounds region access %#lx-%#lx "
+                "(size %#lx)", ra->offset, ra->offset + ra->count,
+                vfu_ctx->reg_info[index].size);
+
+        return false;
+    }
+
+    if (device_is_stopped_and_copying(vfu_ctx->migration) &&
+        !is_migr_reg(vfu_ctx, index)) {
+        vfu_log(vfu_ctx, LOG_ERR,
+                "cannot access region %u while device in stop-and-copy state",
+                index);
+        return false;
+    }
+
+    return true;
+}
+
+static int
+handle_region_access(vfu_ctx_t *vfu_ctx, uint32_t size, uint16_t cmd,
+                     void **data, size_t *len,
+                     struct vfio_user_region_access *ra)
+{
+    ssize_t ret;
+    char *buf;
+
+    assert(vfu_ctx != NULL);
+    assert(data != NULL);
+    assert(ra != NULL);
+
+    if (!valid_region_access(vfu_ctx, size, cmd, ra)) {
+        return -EINVAL;
+    }
+
+    *len = sizeof (*ra);
+    if (cmd == VFIO_USER_REGION_READ) {
+        *len += ra->count;
+    }
+    *data = calloc(1, *len);
+    if (*data == NULL) {
+        return -ENOMEM;
+    }
+    if (cmd == VFIO_USER_REGION_READ) {
+        buf = (char *)(((struct vfio_user_region_access*)(*data)) + 1);
+    } else {
+        buf = (char *)(ra + 1);
+    }
+
+    ret = region_access(vfu_ctx, ra->region, cmd == VFIO_USER_REGION_WRITE,
+                        buf, ra->offset, ra->count);
+
+    if (ret != ra->count) {
+        vfu_log(vfu_ctx, LOG_ERR, "failed to %s %#x-%#lx: %d",
+                cmd == VFIO_USER_REGION_WRITE ? "write" : "read",
+                ra->count, ra->offset + ra->count - 1, ret);
+        /* FIXME we should return whatever has been accessed, not an error */
+        if (ret >= 0) {
+            ret = -EINVAL;
+        }
+        return ret;
+    }
+
+    ra = *data;
+    ra->count = ret;
+
+    return 0;
+}
+
+#define VFU_REGION_SHIFT 40
+
+static inline uint64_t
+region_to_offset(uint32_t region)
+{
+    return (uint64_t)region << VFU_REGION_SHIFT;
 }
 
 long
@@ -254,183 +401,6 @@ dev_get_reginfo(vfu_ctx_t *vfu_ctx, uint32_t index, uint32_t argsz,
             (*vfio_reg)->size, (*vfio_reg)->argsz);
 
     return 0;
-}
-
-int
-vfu_get_region(loff_t pos, size_t count, loff_t *off)
-{
-    int r;
-
-    assert(off != NULL);
-
-    r = offset_to_region(pos);
-    if ((int)offset_to_region(pos + count) != r) {
-        return -ENOENT;
-    }
-    *off = pos - region_to_offset(r);
-
-    return r;
-}
-
-static ssize_t
-do_access(vfu_ctx_t *vfu_ctx, char *buf, uint8_t count, uint64_t pos, bool is_write)
-{
-    int idx;
-    loff_t offset;
-
-    assert(vfu_ctx != NULL);
-    assert(buf != NULL);
-    assert(count == 1 || count == 2 || count == 4 || count == 8);
-
-    idx = vfu_get_region(pos, count, &offset);
-    if (idx < 0) {
-        vfu_log(vfu_ctx, LOG_ERR, "invalid region %d", idx);
-        return idx;
-    }
-
-    if (idx < 0 || idx >= (int)vfu_ctx->nr_regions) {
-        vfu_log(vfu_ctx, LOG_ERR, "bad region %d", idx);
-        return -EINVAL;
-    }
-
-    if (idx == VFU_PCI_DEV_CFG_REGION_IDX) {
-        return pci_config_space_access(vfu_ctx, buf, count, offset, is_write);
-    }
-
-    if (is_migr_reg(vfu_ctx, idx)) {
-        if (offset + count > vfu_ctx->reg_info[idx].size) {
-            vfu_log(vfu_ctx, LOG_ERR, "read %#lx-%#lx past end of migration region (%#x)",
-                    offset, offset + count - 1,
-                    vfu_ctx->reg_info[idx].size);
-            return -EINVAL;
-        }
-        return handle_migration_region_access(vfu_ctx, vfu_ctx->migration,
-                                              buf, count, offset, is_write);
-    }
-
-    /*
-     * Checking whether a callback exists might sound expensive however this
-     * code is not performance critical. This works well when we don't expect a
-     * region to be used, so the user of the library can simply leave the
-     * callback NULL in vfu_create_ctx.
-     */
-    if (vfu_ctx->reg_info[idx].fn != NULL) {
-        return vfu_ctx->reg_info[idx].fn(vfu_ctx, buf, count, offset, is_write);
-    }
-
-    vfu_log(vfu_ctx, LOG_ERR, "no callback for region %d", idx);
-
-    return -EINVAL;
-}
-
-/*
- * Returns the number of bytes processed on success or a negative number on
- * error.
- *
- * TODO function naming, general cleanup of access path
- * FIXME we must be able to return values up to uint32_t bit, or negative on
- * error. Better to make return value an int and return the number of bytes
- * processed via an argument.
- */
-static ssize_t
-_vfu_access(vfu_ctx_t *vfu_ctx, char *buf, uint32_t count, uint64_t *ppos,
-          bool is_write)
-{
-    uint32_t done = 0;
-    int ret;
-
-    assert(vfu_ctx != NULL);
-    /* buf and ppos can be NULL if count is 0 */
-
-    while (count) {
-        size_t size;
-        /*
-         * Limit accesses to qword and enforce alignment. Figure out whether
-         * the PCI spec requires this
-         * FIXME while this makes sense for registers, we might be able to relax
-         * this requirement and make some transfers more efficient. Maybe make
-         * this a per-region option that can be set by the user?
-         */
-        if (count >= 8 && !(*ppos % 8)) {
-           size = 8;
-        } else if (count >= 4 && !(*ppos % 4)) {
-            size = 4;
-        } else if (count >= 2 && !(*ppos % 2)) {
-            size = 2;
-        } else {
-            size = 1;
-        }
-        ret = do_access(vfu_ctx, buf, size, *ppos, is_write);
-        if (ret <= 0) {
-            vfu_log(vfu_ctx, LOG_ERR, "failed to %s %#lx-%#lx: %s",
-                    is_write ? "write to" : "read from", *ppos, *ppos + size - 1,
-                    strerror(-ret));
-            /*
-             * TODO if ret < 0 then it might contain a legitimate error code, why replace it with EFAULT?
-             */
-            return -EFAULT;
-        }
-        if (ret != (int)size) {
-            vfu_log(vfu_ctx, LOG_DEBUG, "bad read %d != %ld", ret, size);
-        }
-        count -= size;
-        done += size;
-        *ppos += size;
-        buf += size;
-    }
-    return done;
-}
-
-static inline int
-vfu_access(vfu_ctx_t *vfu_ctx, bool is_write, char *rwbuf, uint32_t count,
-             uint64_t *pos)
-{
-    uint32_t processed = 0, _count;
-    int ret;
-
-    assert(vfu_ctx != NULL);
-    assert(rwbuf != NULL);
-    assert(pos != NULL);
-
-    vfu_log(vfu_ctx, LOG_DEBUG, "%s %#lx-%#lx", is_write ? "W" : "R", *pos,
-            *pos + count - 1);
-
-#ifdef VFU_VERBOSE_LOGGING
-    if (is_write) {
-        dump_buffer("buffer write", rwbuf, count);
-    }
-#endif
-
-    _count = count;
-
-    if (pci_is_hdr_access(*pos)) {
-        ret = pci_hdr_access(vfu_ctx, &_count, pos, is_write, rwbuf);
-        if (ret != 0) {
-            /* FIXME shouldn't we fail here? */
-            vfu_log(vfu_ctx, LOG_ERR, "failed to access PCI header: %s",
-                    strerror(-ret));
-#ifdef VFU_VERBOSE_LOGGING
-            dump_buffer("buffer write", rwbuf, _count);
-#endif
-        }
-    }
-
-    /*
-     * count is how much has been processed by pci_hdr_access,
-     * _count is how much there's left to be processed by vfu_access
-     */
-    processed = count - _count;
-    ret = _vfu_access(vfu_ctx, rwbuf + processed, _count, pos, is_write);
-    if (ret >= 0) {
-        ret += processed;
-#ifdef VFU_VERBOSE_LOGGING
-        if (!is_write && err == ret) {
-            dump_buffer("buffer read", rwbuf, ret);
-        }
-#endif
-    }
-
-    return ret;
 }
 
 /* TODO merge with dev_get_reginfo */
@@ -591,96 +561,6 @@ handle_device_reset(vfu_ctx_t *vfu_ctx)
     if (vfu_ctx->reset != NULL) {
         return vfu_ctx->reset(vfu_ctx);
     }
-    return 0;
-}
-
-static int
-validate_region_access(vfu_ctx_t *vfu_ctx, uint32_t size, uint16_t cmd,
-                       struct vfio_user_region_access *region_access)
-{
-    assert(region_access != NULL);
-
-    if (size < sizeof *region_access) {
-        vfu_log(vfu_ctx, LOG_ERR, "message size too small (%d)", size);
-        return -EINVAL;
-    }
-
-    if (region_access->region > vfu_ctx->nr_regions ||  region_access->count <= 0) {
-        vfu_log(vfu_ctx, LOG_ERR, "bad region %d and/or count %d",
-                region_access->region, region_access->count);
-        return -EINVAL;
-    }
-
-    if (device_is_stopped_and_copying(vfu_ctx->migration) &&
-        !is_migr_reg(vfu_ctx, region_access->region)) {
-        vfu_log(vfu_ctx, LOG_ERR,
-                "cannot access region %d while device in stop-and-copy state",
-                region_access->region);
-        return -EINVAL;
-    }
-
-    if (cmd == VFIO_USER_REGION_WRITE &&
-        size - sizeof *region_access != region_access->count)
-    {
-        vfu_log(vfu_ctx, LOG_ERR, "bad region access, expected %lu, actual %d",
-                size - sizeof *region_access, region_access->count);
-        return -EINVAL;
-    }
-
-    return 0;
-}
-
-static int
-handle_region_access(vfu_ctx_t *vfu_ctx, uint32_t size, uint16_t cmd,
-                     void **data, size_t *len,
-                     struct vfio_user_region_access *region_access)
-{
-    uint64_t count, offset;
-    int ret;
-    char *buf;
-
-    assert(vfu_ctx != NULL);
-    assert(data != NULL);
-    assert(region_access != NULL);
-
-    ret = validate_region_access(vfu_ctx, size, cmd, region_access);
-    if (ret < 0) {
-        return ret;
-    }
-
-    *len = sizeof *region_access;
-    if (cmd == VFIO_USER_REGION_READ) {
-        *len += region_access->count;
-    }
-    *data = calloc(1, *len);
-    if (*data == NULL) {
-        return -ENOMEM;
-    }
-    if (cmd == VFIO_USER_REGION_READ) {
-        buf = (char*)(((struct vfio_user_region_access*)(*data)) + 1);
-    } else {
-        buf = (char*)(region_access + 1);
-    }
-
-    count = region_access->count;
-    offset = region_to_offset(region_access->region) + region_access->offset;
-
-    ret = vfu_access(vfu_ctx, cmd == VFIO_USER_REGION_WRITE, buf, count, &offset);
-    if (ret != (int)region_access->count) {
-        vfu_log(vfu_ctx, LOG_ERR, "failed to %s %#x-%#lx: %d",
-                cmd == VFIO_USER_REGION_WRITE ? "write" : "read",
-                region_access->count,
-                region_access->offset + region_access->count - 1, ret);
-        /* FIXME we should return whatever has been accessed, not an error */
-        if (ret >= 0) {
-            ret = -EINVAL;
-        }
-        return ret;
-    }
-
-    region_access = *data;
-    region_access->count = ret;
-
     return 0;
 }
 

--- a/lib/migration.c
+++ b/lib/migration.c
@@ -387,6 +387,8 @@ migration_region_access_registers(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
     struct migration *migr = vfu_ctx->migration;
     int ret;
 
+    assert(migr != NULL);
+
     switch (pos) {
     case offsetof(struct vfio_device_migration_info, device_state):
         if (count != sizeof(migr->info.device_state)) {
@@ -435,6 +437,7 @@ migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
     struct migration *migr = vfu_ctx->migration;
     ssize_t ret = -EINVAL;
 
+    assert(migr != NULL);
     assert(buf != NULL);
 
     if (pos + count <= sizeof(struct vfio_device_migration_info)) {

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -47,9 +47,8 @@ struct migration *
 init_migration(const vfu_migration_t * const vfu_migr, int *err);
 
 ssize_t
-handle_migration_region_access(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                               char *buf, size_t count,
-                               loff_t pos, bool is_write);
+migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
+                        loff_t pos, bool is_write);
 
 bool
 migration_available(vfu_ctx_t *vfu_ctx);

--- a/lib/pci.c
+++ b/lib/pci.c
@@ -301,16 +301,21 @@ pci_hdr_access(vfu_ctx_t *vfu_ctx, char *buf, size_t *countp,
  * Outside of those areas, if a callback is specified for the region, we'll use
  * that; otherwise, writes are not allowed, and reads are satisfied with
  * memcpy().
+ *
+ * Returns the number of bytes handled, or -errno on error.
  */
 ssize_t
 pci_config_space_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
                         loff_t offset, bool is_write)
 {
-    vfu_region_access_cb_t *cb =
-        vfu_ctx->reg_info[VFU_PCI_DEV_CFG_REGION_IDX].fn;
+    vfu_region_access_cb_t *cb;
     loff_t start = offset;
     ssize_t ret;
     int rc;
+
+    assert(vfu_ctx != NULL);
+
+    cb = vfu_ctx->reg_info[VFU_PCI_DEV_CFG_REGION_IDX].cb;
 
     if (offset < PCI_STD_HEADER_SIZEOF) {
         rc = pci_hdr_access(vfu_ctx, buf, &count, &offset, is_write);

--- a/lib/pci.h
+++ b/lib/pci.h
@@ -36,17 +36,6 @@
 #include "libvfio-user.h"
 #include "private.h"
 
-static inline bool
-pci_is_hdr_access(uint64_t pos)
-{
-    const uint64_t off = region_to_offset(VFU_PCI_DEV_CFG_REGION_IDX);
-    return pos >= off && pos - off < PCI_STD_HEADER_SIZEOF;
-}
-
-int
-pci_hdr_access(vfu_ctx_t *vfu_ctx, uint32_t *count,
-               uint64_t *pos, bool is_write, char *buf);
-
 ssize_t
 pci_config_space_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
                         loff_t pos, bool is_write);

--- a/lib/private.h
+++ b/lib/private.h
@@ -35,22 +35,12 @@
 
 #include "dma.h"
 
-#define VFU_REGION_SHIFT 40
-#define VFU_REGION_MASK  ((1ULL << VFU_REGION_SHIFT) - 1)
-
 static inline int
 ERROR(int err)
 {
     errno = err;
     return -1;
 }
-
-#ifdef VFU_VERBOSE_LOGGING
-void
-dump_buffer(const char *prefix, const char *buf, uint32_t count);
-#else
-#define dump_buffer(prefix, buf, count)
-#endif
 
 struct transport_ops {
     int (*init)(vfu_ctx_t*);
@@ -139,24 +129,11 @@ struct vfu_ctx {
     vfu_dev_type_t          dev_type;
 };
 
-int
-vfu_pci_hdr_access(vfu_ctx_t *vfu_ctx, uint32_t *count,
-                   uint64_t *pos, bool write, char *buf);
+void
+dump_buffer(const char *prefix, const char *buf, uint32_t count);
 
 vfu_reg_info_t *
 vfu_get_region_info(vfu_ctx_t *vfu_ctx);
-
-static inline uint64_t
-region_to_offset(uint32_t region)
-{
-    return (uint64_t)region << VFU_REGION_SHIFT;
-}
-
-static inline uint32_t
-offset_to_region(uint64_t offset)
-{
-    return (offset >> VFU_REGION_SHIFT) & VFU_REGION_MASK;
-}
 
 int
 handle_dma_map_or_unmap(vfu_ctx_t *vfu_ctx, uint32_t size, bool map,

--- a/lib/private.h
+++ b/lib/private.h
@@ -89,7 +89,7 @@ typedef struct  {
      * Note that the memory of the region is owned by the user, except for the
      * standard header (first 64 bytes) of the PCI configuration space.
      */
-    vfu_region_access_cb_t  *fn;
+    vfu_region_access_cb_t  *cb;
 
     struct vfu_sparse_mmap_areas *mmap_areas; /* sparse mmap areas */
     int fd;

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -483,7 +483,6 @@ test_get_region_info(UNUSED void **state)
     mmap_areas->areas[0].iov_base = (void*)0x8badf00d;
     mmap_areas->areas[0].iov_len = 0x0d15ea5e;
     vfu_ctx.reg_info[1].mmap_areas = mmap_areas;
-    vfu_ctx.reg_info[1].flags |= VFIO_REGION_INFO_FLAG_MMAP;
     assert_int_equal(0,
                      dev_get_reginfo(&vfu_ctx, index, argsz, &vfio_reg,
                                      &fds, &nr_fds));

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -471,7 +471,8 @@ test_get_region_info(UNUSED void **state)
                      dev_get_reginfo(&vfu_ctx, index, argsz, &vfio_reg,
                                      &fds, &nr_fds));
     assert_int_equal(sizeof(struct vfio_region_info), vfio_reg->argsz);
-    assert_int_equal(VFU_REGION_FLAG_RW, vfio_reg->flags);
+    assert_int_equal(VFIO_REGION_INFO_FLAG_READ | VFIO_REGION_INFO_FLAG_WRITE |
+                     VFIO_REGION_INFO_FLAG_MMAP, vfio_reg->flags);
     assert_int_equal(1, vfio_reg->index);
     assert_int_equal(0x10000000000, vfio_reg->offset);
     assert_int_equal(0xdeadbeef, vfio_reg->size);
@@ -488,7 +489,8 @@ test_get_region_info(UNUSED void **state)
                                      &fds, &nr_fds));
     assert_int_equal(argsz + sizeof(struct vfio_region_info_cap_sparse_mmap) + sizeof(struct vfio_region_sparse_mmap_area),
                      vfio_reg->argsz);
-    assert_int_equal(VFU_REGION_FLAG_RW | VFIO_REGION_INFO_FLAG_MMAP | VFIO_REGION_INFO_FLAG_CAPS,
+    assert_int_equal(VFIO_REGION_INFO_FLAG_READ | VFIO_REGION_INFO_FLAG_WRITE |
+                     VFIO_REGION_INFO_FLAG_MMAP | VFIO_REGION_INFO_FLAG_CAPS,
                      vfio_reg->flags);
     assert_int_equal(0, nr_fds);
 
@@ -668,25 +670,36 @@ test_setup_sparse_region(void **state __attribute__((unused)))
             .iov_len = 0x1000
         }
     };
+    int ret;
 
-    /* bad fd */
-    assert_int_equal(-1,
-                     vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
-                                      0x2000, NULL, 0, mmap_areas, 2, -1));
-    assert_int_equal(EBADF, errno);
+    /* invalid mappable settings */
+    ret = vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
+                           0x2000, NULL, 0, mmap_areas, 2, -1);
+    assert_int_equal(-1, ret);
+    assert_int_equal(EINVAL, errno);
+
+    ret = vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
+                           0x2000, NULL, 0, NULL, 0, 1);
+    assert_int_equal(-1, ret);
+    assert_int_equal(EINVAL, errno);
+
+    ret = vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
+                           0x2000, NULL, 0, mmap_areas, 0, 1);
+    assert_int_equal(-1, ret);
+    assert_int_equal(EINVAL, errno);
 
     /* sparse region exceeds region size */
     mmap_areas[1].iov_len = 0x1001;
-    assert_int_equal(-1,
-                     vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
-                                      0x2000, NULL, 0, mmap_areas, 2, 0));
+    ret = vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
+                            0x2000, NULL, 0, mmap_areas, 2, 0);
+    assert_int_equal(-1, ret);
     assert_int_equal(EINVAL, errno);
 
     /* sparse region within region size */
     mmap_areas[1].iov_len = 0x1000;
-    assert_int_equal(0,
-                     vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
-                                      0x2000, NULL, 0, mmap_areas, 2, 0));
+    ret = vfu_setup_region(&vfu_ctx, VFU_PCI_DEV_BAR0_REGION_IDX,
+                           0x2000, NULL, 0, mmap_areas, 2, 0);
+    assert_int_equal(0, ret);
 }
 
 static void

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -473,12 +473,12 @@ test_get_region_info(UNUSED void **state)
     assert_int_equal(sizeof(struct vfio_region_info), vfio_reg->argsz);
     assert_int_equal(VFU_REGION_FLAG_RW, vfio_reg->flags);
     assert_int_equal(1, vfio_reg->index);
-    assert_int_equal(0x10000000000, region_to_offset(vfio_reg->index));
+    assert_int_equal(0x10000000000, vfio_reg->offset);
     assert_int_equal(0xdeadbeef, vfio_reg->size);
     assert_int_equal(0, nr_fds);
 
     /* regions caps (sparse mmap) but argsz too small */
-    mmap_areas->nr_mmap_areas = 1; 
+    mmap_areas->nr_mmap_areas = 1;
     mmap_areas->areas[0].iov_base = (void*)0x8badf00d;
     mmap_areas->areas[0].iov_len = 0x0d15ea5e;
     vfu_ctx.reg_info[1].mmap_areas = mmap_areas;


### PR DESCRIPTION
Various cleanups and fixes to handling of region accesses, including:

- there should be no reason for us to split accesses into 1/2/4/8 byte accesses:
  in general, the client will have already be doing that, and if not, there's no
  particular reason we should be the ones to split up such larger accesses.

- use a callback for PCI config space reads and writes if one is provided (needs
  more work for capabilities)

Signed-off-by: John Levon <john.levon@nutanix.com>