### PR TITLE
make vfu_region_to_offset public

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -627,6 +627,9 @@ vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
 uint8_t *
 vfu_ctx_get_cap(vfu_ctx_t *vfu_ctx, uint8_t id);
 
+uint64_t
+vfu_region_to_offset(uint32_t region);
+
 #ifdef __cplusplus
 }
 #endif

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -627,6 +627,13 @@ vfu_pci_setup_caps(vfu_ctx_t *vfu_ctx, vfu_cap_t **caps, int nr_caps);
 uint8_t *
 vfu_ctx_get_cap(vfu_ctx_t *vfu_ctx, uint8_t id);
 
+/**
+ * Returns the memory offset where the specific region starts in device memory.
+ *
+ * @region: the region to translate
+ *
+ * @returns the absolute offset
+ */
 uint64_t
 vfu_region_to_offset(uint32_t region);
 

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -239,9 +239,7 @@ dev_get_reginfo(vfu_ctx_t *vfu_ctx, uint32_t index, uint32_t argsz,
 
     *nr_fds = 0;
     if (caps_size > 0) {
-        if (vfu_reg->mmap_areas != NULL) {
-            (*vfio_reg)->flags |= VFIO_REGION_INFO_FLAG_CAPS;
-        }
+        (*vfio_reg)->flags |= VFIO_REGION_INFO_FLAG_CAPS;
         if (argsz >= (*vfio_reg)->argsz) {
             dev_get_caps(vfu_ctx, vfu_reg, is_migr_reg(vfu_ctx, index),
                          *vfio_reg, fds, nr_fds);
@@ -1590,6 +1588,12 @@ vfu_dma_write(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data)
     free(dma_send);
 
     return ret;
+}
+
+uint64_t
+vfu_region_to_offset(uint32_t region)
+{
+    return region_to_offset(region);
 }
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
This is required for SPDK to access the migration region.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>