### PR TITLE
test_process_command_free_passed_fds: fix fd array size

### DIFF
--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -345,6 +345,7 @@ test_process_command_free_passed_fds(void **state __attribute__((unused)))
 {
     vfu_ctx_t vfu_ctx = {
         .conn_fd = 0xcafebabe,
+        .client_max_fds = ARRAY_SIZE(fds),
         .migration = (struct migration*)0x8badf00d
     };
 


### PR DESCRIPTION
We need to initialize .client_max_fds to get the fd array allocated properly in
process_request().

Signed-off-by: John Levon <john.levon@nutanix.com>