### PR TITLE
close listening socket in vfu_destroy_ctx()

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1088,6 +1088,11 @@ vfu_destroy_ctx(vfu_ctx_t *vfu_ctx)
     if (vfu_ctx->trans->detach != NULL) {
         vfu_ctx->trans->detach(vfu_ctx);
     }
+
+    if (vfu_ctx->trans->fini != NULL) {
+        vfu_ctx->trans->fini(vfu_ctx);
+    }
+
     if (vfu_ctx->dma != NULL) {
         dma_controller_destroy(vfu_ctx->dma);
     }
@@ -1123,6 +1128,8 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
     vfu_ctx_t *vfu_ctx = NULL;
     int err = 0;
 
+    //FIXME: Validate arguments.
+
     if (trans != VFU_TRANS_SOCK) {
         errno = ENOTSUP;
         return NULL;
@@ -1138,11 +1145,11 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
         errno = ENOMEM;
         return NULL;
     }
+
+    vfu_ctx->fd = -1;
+    vfu_ctx->conn_fd = -1;
     vfu_ctx->dev_type = dev_type;
     vfu_ctx->trans = &sock_transport_ops;
-
-    //FIXME: Validate arguments.
-    // Set other context data.
     vfu_ctx->pvt = pvt;
     vfu_ctx->flags = flags;
     vfu_ctx->log_level = LOG_ERR;

--- a/lib/private.h
+++ b/lib/private.h
@@ -44,11 +44,14 @@ ERROR(int err)
 }
 
 struct transport_ops {
-    int (*init)(vfu_ctx_t*);
-    int (*attach)(vfu_ctx_t*);
-    int(*detach)(vfu_ctx_t*);
-    int (*get_request)(vfu_ctx_t*, struct vfio_user_header*,
+    int (*init)(vfu_ctx_t *vfu_ctx);
+    int (*attach)(vfu_ctx_t *vfu_ctx);
+
+    int (*get_request)(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
                        int *fds, size_t *nr_fds);
+
+    void (*detach)(vfu_ctx_t *vfu_ctx);
+    void (*fini)(vfu_ctx_t *vfu_ctx);
 };
 
 typedef enum {

--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -715,12 +715,6 @@ open_sock(vfu_ctx_t *vfu_ctx)
 }
 
 static int
-close_sock(vfu_ctx_t *vfu_ctx)
-{
-    return close(vfu_ctx->conn_fd);
-}
-
-static int
 get_request_sock(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
                  int *fds, size_t *nr_fds)
 {
@@ -737,11 +731,30 @@ get_request_sock(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
     return get_msg(hdr, sizeof *hdr, fds, nr_fds, vfu_ctx->conn_fd, sock_flags);
 }
 
+static void
+detach_sock(vfu_ctx_t *vfu_ctx)
+{
+    if (vfu_ctx->conn_fd != -1) {
+        (void) close(vfu_ctx->conn_fd);
+        vfu_ctx->conn_fd = -1;
+    }
+}
+
+static void
+fini_sock(vfu_ctx_t *vfu_ctx)
+{
+    if (vfu_ctx->fd != -1) {
+        (void) close(vfu_ctx->fd);
+        vfu_ctx->fd = -1;
+    }
+}
+
 struct transport_ops sock_transport_ops = {
     .init = init_sock,
     .attach = open_sock,
-    .detach = close_sock,
     .get_request = get_request_sock,
+    .detach = detach_sock,
+    .fini = fini_sock,
 };
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -580,7 +580,7 @@ test_vfu_ctx_create(void **state __attribute__((unused)))
     assert_int_equal(0, vfu_realize_ctx(vfu_ctx));
 
     patch(close);
-    expect_value(__wrap_close, fd, 0x0);
+    expect_value(__wrap_close, fd, vfu_ctx->fd);
     will_return(__wrap_close, 0);
 
     vfu_destroy_ctx(vfu_ctx);


### PR DESCRIPTION
We were forgetting to close vfu_ctx->fd, add a tran callback for this. While
we're there, clean up the tran callbacks somewhat.

Signed-off-by: John Levon <john.levon@nutanix.com>