### PR TITLE
open_sock(): remove stale comment

### DIFF
--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -687,10 +687,6 @@ negotiate(vfu_ctx_t *vfu_ctx, int sock)
     return ret;
 }
 
-/**
- * vfu_ctx: libvfio-user context
- * FIXME: this shouldn't be happening as part of vfu_ctx_create().
- */
 static int
 open_sock(vfu_ctx_t *vfu_ctx)
 {


### PR DESCRIPTION
We fixed it so we don't accept() when we create the context, but only when we
attach.

Signed-off-by: John Levon <john.levon@nutanix.com>