### PR TITLE
don't expose -errno in public API

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -140,7 +140,7 @@ vfu_attach_ctx(vfu_ctx_t *vfu_ctx);
  *
  * @vfu_ctx: The libvfio-user context to poll
  *
- * @returns 0 on success, -errno on failure.
+ * @returns 0 on success, -1 on error. Sets errno.
  */
 int
 vfu_run_ctx(vfu_ctx_t *vfu_ctx);
@@ -193,7 +193,7 @@ vfu_setup_log(vfu_ctx_t *vfu_ctx, vfu_log_fn_t *log, int level);
  * @offset: byte offset within the region
  * @is_write: whether or not this is a write
  *
- * @returns the number of bytes read or written, or a negative integer on error
+ * @returns the number of bytes read or written, or -1 on error, setting errno.
  */
 typedef ssize_t (vfu_region_access_cb_t)(vfu_ctx_t *vfu_ctx, char *buf,
                                          size_t count, loff_t offset,
@@ -400,9 +400,14 @@ typedef struct {
      */
     int version;
 
-    /* migration state transition callback */
-    /* TODO rename to vfu_migration_state_transition_callback */
-    /* FIXME maybe we should create a single callback and pass the state? */
+    /*
+     * Migration state transition callback.
+     *
+     * Returns -1 on error, setting errno.
+     *
+     * TODO rename to vfu_migration_state_transition_callback
+     * FIXME maybe we should create a single callback and pass the state?
+     */
     int (*transition)(vfu_ctx_t *vfu_ctx, vfu_migr_state_t state);
 
     /* Callbacks for saving device state */
@@ -433,7 +438,9 @@ typedef struct {
     /*
      * Function that is called to read migration data. offset and size can be
      * any subrange on the offset and size previously returned by prepare_data.
-     * The function must return the amount of data read or -errno on error.
+     * The function must return the amount of data read or -1 on error, setting
+     * errno.
+     *
      * This function can be called even if the migration data can be memory
      * mapped.
      *
@@ -446,7 +453,8 @@ typedef struct {
 
     /*
      * Fuction that is called for writing previously stored device state. The
-     * function must return the amount of data written or -errno on error.
+     * function must return the amount of data written or -1 on error, setting
+     * errno.
      */
     ssize_t (*write_data)(vfu_ctx_t *vfu_ctx, void *buf, __u64 count,
                           __u64 offset);

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1057,9 +1057,9 @@ vfu_run_ctx(vfu_ctx_t *vfu_ctx)
     blocking = !(vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB);
     do {
         err = process_request(vfu_ctx);
-    } while (err >= 0 && blocking);
+    } while (err == 0 && blocking);
 
-    return err >= 0 ? 0 : err;
+    return err == 0 ? 0 : ERROR_INT(-err);
 }
 
 static void

--- a/lib/migration.c
+++ b/lib/migration.c
@@ -528,6 +528,9 @@ migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
         pos -= migr->data_offset;
         if (is_write) {
             ret = migr->callbacks.write_data(vfu_ctx, buf, count, pos);
+            if (ret == -1) {
+                ret = -errno;
+            }
         } else {
             /*
              * FIXME <linux/vfio.h> says:
@@ -538,6 +541,9 @@ migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
              * Does this mean that partial reads are not allowed?
              */
             ret = migr->callbacks.read_data(vfu_ctx, buf, count, pos);
+            if (ret == -1) {
+                ret = -errno;
+            }
         }
     }
 

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -122,8 +122,7 @@ main(int argc, char *argv[])
     ret = vfu_setup_region(vfu_ctx, VFU_PCI_DEV_BAR2_REGION_IDX, 0x100,
                            &bar2_access, VFU_REGION_FLAG_RW, NULL, 0, -1);
     if (ret < 0) {
-        fprintf(stderr, "failed to setup region\n");
-        goto out;
+        err(EXIT_FAILURE, "failed to setup region");
     }
 
     ret = vfu_setup_device_nr_irqs(vfu_ctx, VFU_DEV_INTX_IRQ, 1);
@@ -143,16 +142,13 @@ main(int argc, char *argv[])
 
     ret = vfu_run_ctx(vfu_ctx);
     if (ret != 0) {
-        if (ret != -ENOTCONN && ret != -EINTR) {
-            fprintf(stderr, "failed to realize device emulation\n");
-            goto out;
+        if (errno != ENOTCONN && errno != EINTR) {
+            err(EXIT_FAILURE, "failed to realize device emulation");
         }
-        ret = 0;
     }
 
-out:
     vfu_destroy_ctx(vfu_ctx);
-    return ret;
+    return EXIT_SUCCESS;
 }
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
Regardless of what we do internally, most of our API uses standard mechanisms
for reporting errors. Fix vfu_run_ctx() to do so properly as well, and fix a
couple of other references for user-provided callbacks.

This will require a small fix to SPDK.

Signed-off-by: John Levon <john.levon@nutanix.com>
