### PR TITLE
timeout github actions jobs after 5 minutes

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,6 +2,7 @@ name: pull_request
 on: pull_request
 jobs:
   ubuntu-20:
+    timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -11,6 +12,7 @@ jobs:
           sudo apt-get -y install libjson-c-dev libcmocka-dev clang valgrind
           make pre-push VERBOSE=1
   ubuntu-18:
+    timeout-minutes: 5
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -19,6 +21,7 @@ jobs:
           sudo apt-get -y install libjson-c-dev libcmocka-dev clang valgrind
           make pre-push VERBOSE=1
   centos-7:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     container: centos:7
     steps:
@@ -30,6 +33,7 @@ jobs:
               openssl-devel valgrind
           make pre-push VERBOSE=1
   fedora-rawhide:
+    timeout-minutes: 5
     runs-on: ubuntu-latest
     container: fedora:rawhide
     steps:


### PR DESCRIPTION
The default of 360 minutes isn't really necessary...

Signed-off-by: John Levon <john.levon@nutanix.com>
