### PR TITLE
CI: don't use development version of Fedora

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -35,11 +35,11 @@ jobs:
   fedora-rawhide:
     timeout-minutes: 5
     runs-on: ubuntu-latest
-    container: fedora:rawhide
+    container: fedora
     steps:
       - uses: actions/checkout@v2
       - name: pre-push
         run: |
-          yum -y install gcc make clang cmake json-c-devel libcmocka-devel \
+          dnf -y install --releasever=34 gcc make clang cmake json-c-devel libcmocka-devel \
               openssl-devel pciutils diffutils valgrind
           make pre-push VERBOSE=1


### PR DESCRIPTION
IIUC rawhide is the development version and this might break unexpectedly. Hopefully fixes the following problem:

warning: /var/cache/dnf/rawhide-2d95c80a1fa0a67d/packages/openssl-devel-1.1.1i-3.fc35.x86_64.rpm: Header V4 RSA/SHA256 Signature, key ID 9867c58f: NOKEY
Fedora - Rawhide - Developmental packages for t 1.6 MB/s | 1.6 kB     00:00
GPG key at file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-34-x86_64 (0x45719A39) is already installed
The GPG keys listed for the "Fedora - Rawhide - Developmental packages for the next Fedora release" repository are already installed but they are not correct for this package.
Check that the correct key URLs are configured for this repository.. Failing package is: openssl-devel-1:1.1.1i-3.fc35.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-34-x86_64
Public key for openssl-libs-1.1.1i-3.fc35.x86_64.rpm is not installed. Failing package is: openssl-libs-1:1.1.1i-3.fc35.x86_64
 GPG Keys are configured as: file:///etc/pki/rpm-gpg/RPM-GPG-KEY-fedora-34-x86_64
The downloaded packages were saved in cache until the next successful transaction.
You can remove cached packages by executing 'yum clean packages'.
Error: GPG check FAILED

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>