### PR TITLE
fix VFIO_USER_DEVICE_GET_INFO request size check

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -433,7 +433,7 @@ handle_device_get_info(vfu_ctx_t *vfu_ctx, uint32_t size,
     assert(vfu_ctx != NULL);
     assert(dev_info != NULL);
 
-    if (size < sizeof *dev_info) {
+    if (size != 0) {
         return -EINVAL;
     }
 

--- a/samples/client.c
+++ b/samples/client.c
@@ -367,7 +367,7 @@ get_device_info(int sock, struct vfio_device_info *dev_info)
 
     ret = tran_sock_msg(sock, msg_id,
                         VFIO_USER_DEVICE_GET_INFO,
-                        dev_info, sizeof(*dev_info),
+                        NULL, 0,
                         NULL,
                         dev_info, sizeof(*dev_info));
 

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -991,34 +991,12 @@ test_device_get_info(void **state __attribute__((unused)))
     vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef};
     struct vfio_device_info d = { 0 };
 
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof d, &d));
+    assert_int_equal(0, handle_device_get_info(&vfu_ctx, 0, &d));
     assert_int_equal(sizeof d, d.argsz);
     assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET, d.flags);
     assert_int_equal(vfu_ctx.nr_regions, d.num_regions);
     assert_int_equal(VFU_DEV_NUM_IRQS, d.num_irqs);
 }
-
-/*
- * Checks that handle_device_get_info handles correctly struct vfio_device_info
- * with more fields.
- */
-static void
-test_device_get_info_compat(void **state __attribute__((unused)))
-{
-    vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef};
-    struct vfio_device_info d = { 0 };
-
-    /* more fields */
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, (sizeof d) + 1, &d));
-    assert_int_equal(sizeof d, d.argsz);
-    assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET, d.flags);
-    assert_int_equal(vfu_ctx.nr_regions, d.num_regions);
-    assert_int_equal(VFU_DEV_NUM_IRQS, d.num_irqs);
-
-    /* fewer fields */
-    assert_int_equal(-EINVAL, handle_device_get_info(&vfu_ctx, (sizeof d) - 1, &d));
-}
-
 
 /*
  * Performs various checks when adding sparse memory regions.
@@ -1398,7 +1376,6 @@ int main(void)
         cmocka_unit_test_setup(test_pci_caps, setup),
         cmocka_unit_test_setup(test_pci_ext_caps, setup),
         cmocka_unit_test_setup(test_device_get_info, setup),
-        cmocka_unit_test_setup(test_device_get_info_compat, setup),
         cmocka_unit_test_setup(test_get_region_info, setup),
         cmocka_unit_test_setup(test_setup_sparse_region, setup),
         cmocka_unit_test_setup(test_dma_map_return_value, setup),


### PR DESCRIPTION
The spec says "only the message header is needed in the command
message", we were needlessly requiring the device info struct to be provided
too.

Signed-off-by: John Levon <john.levon@nutanix.com>
