### PR TITLE
rename fedora workflow

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -107,7 +107,7 @@ branches:
           - centos-7
           - ubuntu-18
           - ubuntu-20
-          - fedora-rawhide
+          - fedora-34
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -32,7 +32,7 @@ jobs:
           yum -y install clang cmake json-c-devel libcmocka-devel \
               openssl-devel valgrind
           make pre-push VERBOSE=1
-  fedora-rawhide:
+  fedora-34:
     timeout-minutes: 5
     runs-on: ubuntu-latest
     container: fedora


### PR DESCRIPTION
We're no longer running CI on fedora-rawhide, so rename it.

Signed-off-by: John Levon <john.levon@nutanix.com>
