### PR TITLE
fix DEVICE_GET_INFO specification and handling

### DIFF
--- a/docs/vfio-user.rst
+++ b/docs/vfio-user.rst
@@ -714,7 +714,7 @@ Message format
 +--------------+----------------------------+
 | Command      | 4                          |
 +--------------+----------------------------+
-| Message size | 16 in command, 32 in reply |
+| Message size | 32                         |
 +--------------+----------------------------+
 | Flags        | Reply bit set in reply     |
 +--------------+----------------------------+
@@ -724,9 +724,8 @@ Message format
 +--------------+----------------------------+
 
 This command message is sent by the client to the server to query for basic
-information about the device. Only the message header is needed in the command
-message.  The VFIO device info structure is defined in ``<linux/vfio.h>``
-(``struct vfio_device_info``).
+information about the device. The VFIO device info structure is defined in
+``<linux/vfio.h>`` (``struct vfio_device_info``).
 
 VFIO device info format
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -751,7 +750,9 @@ VFIO device info format
 | num_irqs    | 28     | 4                        |
 +-------------+--------+--------------------------+
 
-* *argsz* is the size of the VFIO device info structure.
+* *argsz* is the size of the VFIO device info structure. This is the only field
+that should be set to non-zero in the request, identifying the client's expected
+size. Currently this is a fixed value.
 * *flags* contains the following device attributes.
 
   * VFIO_DEVICE_FLAGS_RESET indicates that the device supports the

--- a/lib/private.h
+++ b/lib/private.h
@@ -177,7 +177,8 @@ consume_fd(int *fds, size_t nr_fds, size_t index);
 
 int
 handle_device_get_info(vfu_ctx_t *vfu_ctx, uint32_t size,
-                       struct vfio_device_info *dev_info);
+                       struct vfio_device_info *in_dev_info,
+                       struct vfio_device_info *out_dev_info);
 
 long
 dev_get_reginfo(vfu_ctx_t *vfu_ctx, uint32_t index, uint32_t argsz,

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -989,16 +989,19 @@ test_pci_ext_caps(void **state __attribute__((unused)))
 }
 
 static void
-test_device_get_info(void **state __attribute__((unused)))
+test_device_get_info(void **state UNUSED)
 {
-    vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef};
-    struct vfio_device_info d = { 0 };
+    vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef };
+    struct vfio_device_info d_in = { .argsz = sizeof (d_in) };
+    struct vfio_device_info d_out;
 
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof d, &d));
-    assert_int_equal(sizeof d, d.argsz);
-    assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET, d.flags);
-    assert_int_equal(vfu_ctx.nr_regions, d.num_regions);
-    assert_int_equal(VFU_DEV_NUM_IRQS, d.num_irqs);
+    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof (d_in),
+                                               &d_in, &d_out));
+    assert_int_equal(sizeof (d_out), d_out.argsz);
+    assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET,
+                     d_out.flags);
+    assert_int_equal(vfu_ctx.nr_regions, d_out.num_regions);
+    assert_int_equal(VFU_DEV_NUM_IRQS, d_out.num_irqs);
 }
 
 /*
@@ -1006,20 +1009,24 @@ test_device_get_info(void **state __attribute__((unused)))
  * with more fields.
  */
 static void
-test_device_get_info_compat(void **state __attribute__((unused)))
+test_device_get_info_compat(void **state UNUSED)
 {
-    vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef};
-    struct vfio_device_info d = { 0 };
+    vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef };
+    struct vfio_device_info d_in = { .argsz = sizeof (d_in) + 1 };
+    struct vfio_device_info d_out;
 
-    /* more fields */
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, (sizeof d) + 1, &d));
-    assert_int_equal(sizeof d, d.argsz);
-    assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET, d.flags);
-    assert_int_equal(vfu_ctx.nr_regions, d.num_regions);
-    assert_int_equal(VFU_DEV_NUM_IRQS, d.num_irqs);
+    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof (d_in) + 1,
+                                               &d_in, &d_out));
+    assert_int_equal(sizeof (d_out), d_out.argsz);
+    assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET,
+                     d_out.flags);
+    assert_int_equal(vfu_ctx.nr_regions, d_out.num_regions);
+    assert_int_equal(VFU_DEV_NUM_IRQS, d_out.num_irqs);
 
     /* fewer fields */
-    assert_int_equal(-EINVAL, handle_device_get_info(&vfu_ctx, (sizeof d) - 1, &d));
+    assert_int_equal(-EINVAL,
+                     handle_device_get_info(&vfu_ctx, (sizeof (d_in)) - 1,
+                                            &d_in, &d_out));
 }
 
 


### PR DESCRIPTION
The specification for DEVICE_GET_INFO differed from the implementation. After
some discussion, fix the spec such that the struct should be passed in with
->argsz set.

As it happened, the implementation was also wrong: we weren't actually checking
the incoming ->argsz for validation, but we should.

Signed-off-by: John Levon <john.levon@nutanix.com>
