### PR TITLE
drop -Wno-implicit-function-declaration from unit tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -39,8 +39,6 @@ target_link_libraries(unit-tests PUBLIC cmocka json-c)
 
 target_compile_definitions(unit-tests PUBLIC UNIT_TEST)
 
-target_compile_options(unit-tests PUBLIC "-Wno-implicit-function-declaration")
-
 # No "target_link_options" in cmake2
 target_link_libraries(unit-tests PUBLIC
                       "-Wl,--wrap=_dma_controller_do_remove_region")

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -42,4 +42,32 @@ handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
                    struct iovec **iovecs, size_t *nr_iovecs,
                    struct vfio_iommu_type1_dirty_bitmap *dirty_bitmap);
 
+int
+__real_handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
+                          struct iovec **iovecs, size_t *nr_iovecs,
+                          struct vfio_iommu_type1_dirty_bitmap *dirty_bitmap);
+
+int
+__real_dma_controller_add_region(dma_controller_t *dma, dma_addr_t dma_addr,
+                                 size_t size, int fd, off_t offset,
+                                 uint32_t prot);
+
+bool
+__real_device_is_stopped(struct migration *migr);
+
+int
+__real_exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
+                    size_t size, int *fds, size_t *nr_fds, size_t **fds_out,
+                    int *nr_fds_out, struct iovec *_iovecs, struct iovec **iovecs,
+                    size_t *nr_iovecs, bool *free_iovec_data);
+int
+__real_close(int fd);
+
+void
+__real_free(void *ptr);
+
+int
+__real_process_request(vfu_ctx_t *vfu_ctx);
+
+
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */


### PR DESCRIPTION
This might cause undefined program behavior.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>