### PR TITLE
use sizeof() consistently

### DIFF
--- a/include/pci_caps/dsn.h
+++ b/include/pci_caps/dsn.h
@@ -48,7 +48,7 @@ struct dsncap {
     uint32_t sn_lo;
     uint32_t sn_hi;
 } __attribute__((packed));
-_Static_assert(sizeof (struct dsncap) == PCI_EXT_CAP_DSN_SIZEOF,
+_Static_assert(sizeof(struct dsncap) == PCI_EXT_CAP_DSN_SIZEOF,
                "bad DSN Capability size");
 
 #ifdef __cplusplus

--- a/lib/dma.c
+++ b/lib/dma.c
@@ -175,7 +175,7 @@ dma_controller_remove_region(dma_controller_t *dma,
                  * check whether memmove eliminates this warning.
                  */
                 memcpy(region, &dma->regions[dma->nregions - 1],
-                       sizeof *region);
+                       sizeof(*region));
             dma->nregions--;
             return 0;
         }

--- a/lib/irq.c
+++ b/lib/irq.c
@@ -332,7 +332,7 @@ handle_device_get_irq_info(vfu_ctx_t *vfu_ctx, uint32_t size,
     assert(irq_info_in != NULL);
     assert(irq_info_out != NULL);
 
-    if (size != sizeof *irq_info_in || size != irq_info_in->argsz) {
+    if (size != sizeof(*irq_info_in) || size != irq_info_in->argsz) {
         vfu_log(vfu_ctx, LOG_WARNING, "IRQ info size %d", size);
         return -EINVAL;
     }
@@ -349,7 +349,7 @@ handle_device_set_irqs(vfu_ctx_t *vfu_ctx, uint32_t size,
     assert(vfu_ctx != NULL);
     assert(irq_set != NULL);
 
-    if (size < sizeof *irq_set || size != irq_set->argsz) {
+    if (size < sizeof(*irq_set) || size != irq_set->argsz) {
         vfu_log(vfu_ctx, LOG_ERR, "bad size %d", size);
         return -EINVAL;
     }
@@ -422,7 +422,7 @@ vfu_irq_message(vfu_ctx_t *vfu_ctx, uint32_t subindex)
     irq_info.subindex = subindex;
     ret = vfu_ctx->tran->send_msg(vfu_ctx, msg_id,
                                   VFIO_USER_VM_INTERRUPT,
-                                  &irq_info, sizeof irq_info,
+                                  &irq_info, sizeof(irq_info),
                                   NULL, NULL, 0);
     if (ret < 0) {
 	    return ERROR_INT(-ret);

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -71,7 +71,7 @@ vfu_log(vfu_ctx_t *vfu_ctx, int level, const char *fmt, ...)
     }
 
     va_start(ap, fmt);
-    vsnprintf(buf, sizeof buf, fmt, ap);
+    vsnprintf(buf, sizeof(buf), fmt, ap);
     va_end(ap);
     vfu_ctx->log(vfu_ctx, level, buf);
     errno = _errno;
@@ -245,14 +245,14 @@ is_valid_region_access(vfu_ctx_t *vfu_ctx, size_t size, uint16_t cmd,
     assert(vfu_ctx != NULL);
     assert(ra != NULL);
 
-    if (size < sizeof (*ra)) {
+    if (size < sizeof(*ra)) {
         vfu_log(vfu_ctx, LOG_ERR, "message size too small (%d)", size);
         return false;
     }
 
-    if (cmd == VFIO_USER_REGION_WRITE && size - sizeof (*ra) != ra->count) {
+    if (cmd == VFIO_USER_REGION_WRITE && size - sizeof(*ra) != ra->count) {
         vfu_log(vfu_ctx, LOG_ERR, "region write count too small: "
-                "expected %lu, got %u", size - sizeof (*ra), ra->count);
+                "expected %lu, got %u", size - sizeof(*ra), ra->count);
         return false;
     }
 
@@ -303,7 +303,7 @@ handle_region_access(vfu_ctx_t *vfu_ctx, uint32_t size, uint16_t cmd,
         return 0;
     }
 
-    *len = sizeof (*ra);
+    *len = sizeof(*ra);
     if (cmd == VFIO_USER_REGION_READ) {
         *len += ra->count;
     }
@@ -435,12 +435,12 @@ handle_device_get_info(vfu_ctx_t *vfu_ctx, uint32_t in_size,
     assert(in_dev_info != NULL);
     assert(out_dev_info != NULL);
 
-    if (in_size < sizeof (*in_dev_info) ||
-        in_dev_info->argsz < sizeof (*in_dev_info)) {
+    if (in_size < sizeof(*in_dev_info) ||
+        in_dev_info->argsz < sizeof(*in_dev_info)) {
         return -EINVAL;
     }
 
-    out_dev_info->argsz = sizeof (*in_dev_info);
+    out_dev_info->argsz = sizeof(*in_dev_info);
     out_dev_info->flags = VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET;
     out_dev_info->num_regions = vfu_ctx->nr_regions;
     out_dev_info->num_irqs = VFU_DEV_NUM_IRQS;
@@ -633,7 +633,7 @@ handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
     assert(nr_iovecs != NULL);
     assert(dirty_bitmap != NULL);
 
-    if (size < sizeof *dirty_bitmap || size != dirty_bitmap->argsz) {
+    if (size < sizeof(*dirty_bitmap) || size != dirty_bitmap->argsz) {
         vfu_log(vfu_ctx, LOG_ERR, "invalid header size %u", size);
         return -EINVAL;
     }
@@ -646,7 +646,7 @@ handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
     } else if (dirty_bitmap->flags & VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP) {
         ret = handle_dirty_pages_get(vfu_ctx, iovecs, nr_iovecs,
                                      (struct vfio_iommu_type1_dirty_bitmap_get*)(dirty_bitmap + 1),
-                                     size - sizeof *dirty_bitmap);
+                                     size - sizeof(*dirty_bitmap));
     } else {
         vfu_log(vfu_ctx, LOG_ERR, "bad flags %#x", dirty_bitmap->flags);
         ret = -EINVAL;
@@ -670,7 +670,7 @@ validate_header(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size)
 {
     assert(hdr != NULL);
 
-    if (size < sizeof hdr) {
+    if (size < sizeof(hdr)) {
         vfu_log(vfu_ctx, LOG_ERR, "short header read %ld", size);
         return -EINVAL;
     }
@@ -680,7 +680,7 @@ validate_header(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size)
         return -EINVAL;
     }
 
-    if (hdr->msg_size < sizeof hdr) {
+    if (hdr->msg_size < sizeof(hdr)) {
         vfu_log(vfu_ctx, LOG_ERR, "msg%#hx: bad size %d in header",
                 hdr->msg_id, hdr->msg_size);
         return -EINVAL;
@@ -791,7 +791,7 @@ exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size,
         return -EINVAL;
     }
 
-    cmd_data_size = hdr->msg_size - sizeof (*hdr);
+    cmd_data_size = hdr->msg_size - sizeof(*hdr);
 
     if (cmd_data_size > 0) {
         ret = vfu_ctx->tran->recv_body(vfu_ctx, hdr, &cmd_data);
@@ -810,7 +810,7 @@ exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size,
         break;
 
     case VFIO_USER_DEVICE_GET_INFO:
-        dev_info = calloc(1, sizeof *dev_info);
+        dev_info = calloc(1, sizeof(*dev_info));
         if (dev_info == NULL) {
             ret = -ENOMEM;
             break;
@@ -842,7 +842,7 @@ exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size,
         break;
 
     case VFIO_USER_DEVICE_GET_IRQ_INFO:
-        irq_info = calloc(1, sizeof *irq_info);
+        irq_info = calloc(1, sizeof(*irq_info));
         if (irq_info == NULL) {
             ret = -ENOMEM;
             break;
@@ -851,7 +851,7 @@ exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size,
                                          irq_info);
         if (ret == 0) {
             _iovecs[1].iov_base = irq_info;
-            _iovecs[1].iov_len = sizeof *irq_info;
+            _iovecs[1].iov_len = sizeof(*irq_info);
             *iovecs = _iovecs;
             *nr_iovecs = 2;
         } else {
@@ -1183,7 +1183,7 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
      * and move it into vfu_ctx.migration.
      */
     vfu_ctx->nr_regions = VFU_PCI_DEV_NUM_REGIONS;
-    vfu_ctx->reg_info = calloc(vfu_ctx->nr_regions, sizeof *vfu_ctx->reg_info);
+    vfu_ctx->reg_info = calloc(vfu_ctx->nr_regions, sizeof(*vfu_ctx->reg_info));
     if (vfu_ctx->reg_info == NULL) {
         err = -ENOMEM;
         goto err_out;
@@ -1253,7 +1253,7 @@ static int
 copyin_mmap_areas(vfu_reg_info_t *reg_info,
                   struct iovec *mmap_areas, uint32_t nr_mmap_areas)
 {
-    size_t size = nr_mmap_areas * sizeof (*mmap_areas);
+    size_t size = nr_mmap_areas * sizeof(*mmap_areas);
 
     if (mmap_areas == NULL || nr_mmap_areas ==  0) {
         return 0;
@@ -1384,7 +1384,7 @@ vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
 out:
     if (ret < 0) {
         free(reg->mmap_areas);
-        memset(reg, 0, sizeof (*reg));
+        memset(reg, 0, sizeof(*reg));
         return ERROR_INT(-ret);
     }
     return 0;
@@ -1536,7 +1536,7 @@ vfu_dma_read(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, void *data)
     dma_send.addr = sg->dma_addr;
     dma_send.count = sg->length;
     ret = vfu_ctx->tran->send_msg(vfu_ctx, msg_id, VFIO_USER_DMA_READ,
-                                  &dma_send, sizeof dma_send, NULL,
+                                  &dma_send, sizeof(dma_send), NULL,
                                   dma_recv, recv_size);
     memcpy(data, dma_recv->data, sg->length); /* FIXME no need for memcpy */
     free(dma_recv);

--- a/lib/migration.c
+++ b/lib/migration.c
@@ -70,7 +70,7 @@ init_migration(const vfu_migration_callbacks_t * callbacks,
         return NULL;
     }
 
-    migr = calloc(1, sizeof *migr);
+    migr = calloc(1, sizeof(*migr));
     if (migr == NULL) {
         *err = ENOMEM;
         return NULL;

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -138,17 +138,17 @@ cap_write_pm(vfu_ctx_t *vfu_ctx, struct pci_cap *cap, char * buf,
 
     switch (offset - cap->off) {
     case offsetof(struct pmcap, pc):
-        if (count != sizeof (struct pc)) {
+        if (count != sizeof(struct pc)) {
             return -EINVAL;
         }
         assert(false); /* FIXME implement */
         break;
     case offsetof(struct pmcap, pmcs):
-        if (count != sizeof (struct pmcs)) {
+        if (count != sizeof(struct pmcs)) {
             return -EINVAL;
         }
         handle_pmcs_write(vfu_ctx, pm, (struct pmcs *)buf);
-        return sizeof (struct pmcs);
+        return sizeof(struct pmcs);
     }
     return -EINVAL;
 }
@@ -561,7 +561,7 @@ vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, size_t pos, int flags, void *data)
         }
 
         cap.id = ((struct pcie_ext_cap_hdr *)data)->id;
-        cap.hdr_size = sizeof (struct pcie_ext_cap_hdr);
+        cap.hdr_size = sizeof(struct pcie_ext_cap_hdr);
 
         switch (cap.id) {
         case PCI_EXT_CAP_ID_DSN:
@@ -571,7 +571,7 @@ vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, size_t pos, int flags, void *data)
         case PCI_EXT_CAP_ID_VNDR:
             cap.name = "Vendor-Specific";
             cap.cb = ext_cap_write_vendor;
-            cap.hdr_size = sizeof (struct pcie_ext_cap_vsc_hdr);
+            cap.hdr_size = sizeof(struct pcie_ext_cap_vsc_hdr);
             break;
         default:
             vfu_log(vfu_ctx, LOG_ERR, "unsupported capability %#x\n", cap.id);
@@ -592,7 +592,7 @@ vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, size_t pos, int flags, void *data)
         }
 
         cap.id = ((struct cap_hdr *)data)->id;
-        cap.hdr_size = sizeof (struct cap_hdr);
+        cap.hdr_size = sizeof(struct cap_hdr);
 
         switch (cap.id) {
         case PCI_CAP_ID_PM:
@@ -610,7 +610,7 @@ vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, size_t pos, int flags, void *data)
         case PCI_CAP_ID_VNDR:
             cap.name = "Vendor-Specific";
             cap.cb = cap_write_vendor;
-            cap.hdr_size = sizeof (struct vsc);
+            cap.hdr_size = sizeof(struct vsc);
             break;
         default:
             vfu_log(vfu_ctx, LOG_ERR, "unsupported capability %#x\n", cap.id);
@@ -632,10 +632,10 @@ vfu_pci_add_capability(vfu_ctx_t *vfu_ctx, size_t pos, int flags, void *data)
 
     if (extended) {
         memcpy(&vfu_ctx->pci.ext_caps[vfu_ctx->pci.nr_ext_caps],
-               &cap, sizeof (cap));
+               &cap, sizeof(cap));
         vfu_ctx->pci.nr_ext_caps++;
     } else {
-        memcpy(&vfu_ctx->pci.caps[vfu_ctx->pci.nr_caps], &cap, sizeof (cap));
+        memcpy(&vfu_ctx->pci.caps[vfu_ctx->pci.nr_caps], &cap, sizeof(cap));
         vfu_ctx->pci.nr_caps++;
     }
 
@@ -647,7 +647,7 @@ vfu_pci_find_next_ext_capability(vfu_ctx_t *vfu_ctx, size_t offset, int cap_id)
 {
     struct pcie_ext_cap_hdr *hdr = NULL;
 
-    if (offset + sizeof (*hdr) >= pci_config_space_size(vfu_ctx)) {
+    if (offset + sizeof(*hdr) >= pci_config_space_size(vfu_ctx)) {
         errno = EINVAL;
         return 0;
     }
@@ -663,7 +663,7 @@ vfu_pci_find_next_ext_capability(vfu_ctx_t *vfu_ctx, size_t offset, int cap_id)
     for (;;) {
         offset = (uint8_t *)hdr - pci_config_space_ptr(vfu_ctx, 0);
 
-        if (offset + sizeof (*hdr) >= pci_config_space_size(vfu_ctx)) {
+        if (offset + sizeof(*hdr) >= pci_config_space_size(vfu_ctx)) {
             errno = EINVAL;
             return 0;
         }

--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -68,7 +68,7 @@ tran_sock_send_iovec(int sock, uint16_t msg_id, bool is_reply,
     struct vfio_user_header hdr = {.msg_id = msg_id};
     struct msghdr msg;
     size_t i;
-    size_t size = count * sizeof *fds;
+    size_t size = count * sizeof(*fds);
     char *buf;
 
     if (nr_iovecs == 0) {
@@ -216,7 +216,7 @@ tran_sock_recv_fds(int sock, struct vfio_user_header *hdr, bool is_reply,
 
     /* FIXME if ret == -1 then fcntl can overwrite recv's errno */
 
-    ret = get_msg(hdr, sizeof *hdr, fds, nr_fds, sock, 0);
+    ret = get_msg(hdr, sizeof(*hdr), fds, nr_fds, sock, 0);
     if (ret == -1) {
         return -errno;
     }
@@ -248,8 +248,8 @@ tran_sock_recv_fds(int sock, struct vfio_user_header *hdr, bool is_reply,
         }
     }
 
-    if (len != NULL && *len > 0 && hdr->msg_size > sizeof *hdr) {
-        ret = recv(sock, data, MIN(hdr->msg_size - sizeof *hdr, *len),
+    if (len != NULL && *len > 0 && hdr->msg_size > sizeof(*hdr)) {
+        ret = recv(sock, data, MIN(hdr->msg_size - sizeof(*hdr), *len),
                    MSG_WAITALL);
         if (ret < 0) {
             return ret;
@@ -289,9 +289,9 @@ tran_sock_recv_alloc(int sock, struct vfio_user_header *hdr, bool is_reply,
         return ret;
     }
 
-    assert(hdr->msg_size >= sizeof (*hdr));
+    assert(hdr->msg_size >= sizeof(*hdr));
 
-    len = hdr->msg_size - sizeof (*hdr);
+    len = hdr->msg_size - sizeof(*hdr);
 
     if (len == 0) {
         *datap = NULL;
@@ -339,7 +339,7 @@ tran_sock_msg_iovec(int sock, uint16_t msg_id, enum vfio_user_command cmd,
         return ret;
     }
     if (hdr == NULL) {
-        hdr = alloca(sizeof *hdr);
+        hdr = alloca(sizeof(*hdr));
     }
     return tran_sock_recv_fds(sock, hdr, true, &msg_id, recv_data, &recv_len,
                               recv_fds, recv_fd_count);
@@ -411,7 +411,7 @@ tran_sock_init(vfu_ctx_t *vfu_ctx)
         }
     }
 
-    ret = snprintf(addr.sun_path, sizeof addr.sun_path, "%s", vfu_ctx->uuid);
+    ret = snprintf(addr.sun_path, sizeof(addr.sun_path), "%s", vfu_ctx->uuid);
     if (ret >= (int)sizeof(addr.sun_path)) {
         ret = -ENAMETOOLONG;
     }
@@ -564,7 +564,7 @@ recv_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t *msg_idp,
         goto out;
     }
 
-    if (vlen < sizeof (*cversion)) {
+    if (vlen < sizeof(*cversion)) {
         vfu_log(vfu_ctx, LOG_ERR,
                 "msg%#hx: VFIO_USER_VERSION: invalid size %lu", *msg_idp, vlen);
         ret = -EINVAL;
@@ -580,9 +580,9 @@ recv_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t *msg_idp,
 
     vfu_ctx->client_max_fds = 1;
 
-    if (vlen > sizeof (*cversion)) {
+    if (vlen > sizeof(*cversion)) {
         const char *json_str = (const char *)cversion->data;
-        size_t len = vlen - sizeof (*cversion);
+        size_t len = vlen - sizeof(*cversion);
         size_t pgsize = 0;
 
         if (json_str[len - 1] != '\0') {
@@ -647,7 +647,7 @@ send_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t msg_id,
     int slen;
 
     if (vfu_ctx->migration == NULL) {
-        slen = snprintf(server_caps, sizeof (server_caps),
+        slen = snprintf(server_caps, sizeof(server_caps),
             "{"
                 "\"capabilities\":{"
                     "\"max_fds\":%u,"
@@ -655,7 +655,7 @@ send_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t msg_id,
                 "}"
              "}", SERVER_MAX_FDS, SERVER_MAX_MSG_SIZE);
     } else {
-        slen = snprintf(server_caps, sizeof (server_caps),
+        slen = snprintf(server_caps, sizeof(server_caps),
             "{"
                 "\"capabilities\":{"
                     "\"max_fds\":%u,"
@@ -675,7 +675,7 @@ send_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t msg_id,
 
     /* [0] is for the header. */
     iovecs[1].iov_base = &sversion;
-    iovecs[1].iov_len = sizeof (sversion);
+    iovecs[1].iov_len = sizeof(sversion);
     iovecs[2].iov_base = server_caps;
     /* Include the NUL. */
     iovecs[2].iov_len = slen + 1;
@@ -755,7 +755,7 @@ tran_sock_get_request(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
     if (vfu_ctx->flags & LIBVFIO_USER_FLAG_ATTACH_NB) {
         sock_flags = MSG_DONTWAIT | MSG_WAITALL;
     }
-    return get_msg(hdr, sizeof *hdr, fds, nr_fds, ts->conn_fd, sock_flags);
+    return get_msg(hdr, sizeof(*hdr), fds, nr_fds, ts->conn_fd, sock_flags);
 }
 
 static int
@@ -779,7 +779,7 @@ tran_sock_recv_body(vfu_ctx_t *vfu_ctx, const struct vfio_user_header *hdr,
 
     ts = vfu_ctx->tran_data;
 
-    body_size = hdr->msg_size - sizeof (*hdr);
+    body_size = hdr->msg_size - sizeof(*hdr);
 
     data = malloc(body_size);
 

--- a/samples/server.c
+++ b/samples/server.c
@@ -346,7 +346,7 @@ migration_read_data(vfu_ctx_t *vfu_ctx, void *buf, __u64 size, __u64 offset)
     memcpy(buf, server_data->bar1, server_data->bar1_size);
     if (server_data->migration.state == VFU_MIGR_STATE_STOP_AND_COPY) {
         memcpy(buf + server_data->bar1_size, &server_data->bar0,
-               sizeof server_data->bar0);
+               sizeof(server_data->bar0));
     }
     server_data->migration.pending_bytes = 0;
 
@@ -376,12 +376,12 @@ migration_write_data(vfu_ctx_t *vfu_ctx, void *data, __u64 size, __u64 offset)
     if (size == 0) {
         return 0;
     }
-    if (size != sizeof server_data->bar0) {
+    if (size != sizeof(server_data->bar0)) {
         errno = EINVAL;
         return -1;
     }
-    memcpy(&server_data->bar0, buf, sizeof server_data->bar0);
-    ret = bar0_access(vfu_ctx, buf, sizeof server_data->bar0, 0, true);
+    memcpy(&server_data->bar0, buf, sizeof(server_data->bar0));
+    ret = bar0_access(vfu_ctx, buf, sizeof(server_data->bar0), 0, true);
     assert(ret == (int)size); /* FIXME */
 
     return 0;

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -162,7 +162,7 @@ test_dma_add_regions_mixed(void **state __attribute__((unused)))
     expect_value(__wrap_dma_controller_add_region, offset, r[1].offset);
     expect_value(__wrap_dma_controller_add_region, prot, r[1].prot);
 
-    assert_int_equal(0, handle_dma_map_or_unmap(&vfu_ctx, sizeof r, true, &fd, 1, r));
+    assert_int_equal(0, handle_dma_map_or_unmap(&vfu_ctx, sizeof(r), true, &fd, 1, r));
 }
 
 /*
@@ -275,7 +275,7 @@ test_dma_controller_add_region_no_fd(void **state __attribute__((unused)))
     off_t offset = 0;
     dma_memory_region_t *r;
 
-    memset(dma, 0, sizeof (*dma) + sizeof(dma_memory_region_t));
+    memset(dma, 0, sizeof(*dma) + sizeof(dma_memory_region_t));
 
     dma->vfu_ctx = &vfu_ctx;
     dma->max_regions = 1;
@@ -642,10 +642,10 @@ test_pci_caps(void **state __attribute__((unused)))
     vfu_ctx_t vfu_ctx = { .pci.config_space = &config_space,
                           .reg_info = reg_info,
     };
-    struct vsc *vsc1 = alloca(sizeof (*vsc1) + 3);
-    struct vsc *vsc2 = alloca(sizeof (*vsc2) + 13);
-    struct vsc *vsc3 = alloca(sizeof (*vsc3) + 13);
-    struct vsc *vsc4 = alloca(sizeof (*vsc4) + 13);
+    struct vsc *vsc1 = alloca(sizeof(*vsc1) + 3);
+    struct vsc *vsc2 = alloca(sizeof(*vsc2) + 13);
+    struct vsc *vsc3 = alloca(sizeof(*vsc3) + 13);
+    struct vsc *vsc4 = alloca(sizeof(*vsc4) + 13);
     struct pmcap pm = { { 0 } };
     size_t expoffsets[] = {
         PCI_STD_HEADER_SIZEOF,
@@ -658,10 +658,10 @@ test_pci_caps(void **state __attribute__((unused)))
     size_t offset;
     ssize_t ret;
 
-    memset(&config_space, 0, sizeof (config_space));
+    memset(&config_space, 0, sizeof(config_space));
 
     vfu_ctx.reg_info = calloc(VFU_PCI_DEV_NUM_REGIONS,
-                              sizeof (*vfu_ctx.reg_info));
+                              sizeof(*vfu_ctx.reg_info));
 
     pm.hdr.id = PCI_CAP_ID_PM;
     pm.pmcs.raw = 0xef01;
@@ -771,14 +771,14 @@ test_pci_caps(void **state __attribute__((unused)))
     pm.pmcs.raw = 0xffff;
 
     ret = pci_config_space_access(&vfu_ctx, (char *)&pm.pmcs,
-                                  sizeof (struct pmcs), expoffsets[0] +
+                                  sizeof(struct pmcs), expoffsets[0] +
                                   offsetof(struct pmcap, pmcs), true);
 
-    assert_int_equal(sizeof (struct pmcs), ret);
+    assert_int_equal(sizeof(struct pmcs), ret);
 
     assert_memory_equal(pci_config_space_ptr(&vfu_ctx, expoffsets[0] +
                                              offsetof(struct pmcap, pmcs)),
-                        &pm.pmcs, sizeof (struct pmcs));
+                        &pm.pmcs, sizeof(struct pmcs));
 
     /* check read only capability */
 
@@ -814,9 +814,9 @@ test_pci_ext_caps_region_cb(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
     uint8_t *ptr = pci_config_space_ptr(vfu_ctx, offset);
 
     assert_int_equal(is_write, true);
-    assert_int_equal(offset, PCI_CFG_SPACE_SIZE + sizeof (struct dsncap) +
-                     sizeof (struct pcie_ext_cap_vsc_hdr) + 8 +
-                     sizeof (struct pcie_ext_cap_vsc_hdr));
+    assert_int_equal(offset, PCI_CFG_SPACE_SIZE + sizeof(struct dsncap) +
+                     sizeof(struct pcie_ext_cap_vsc_hdr) + 8 +
+                     sizeof(struct pcie_ext_cap_vsc_hdr));
     assert_int_equal(count, 10);
     assert_memory_equal(ptr, "Hello world.", 10);
     memcpy(ptr, buf, count);
@@ -834,15 +834,15 @@ test_pci_ext_caps(void **state __attribute__((unused)))
                           .reg_info = reg_info,
     };
 
-    struct pcie_ext_cap_vsc_hdr *vsc1 = alloca(sizeof (*vsc1) + 5);
-    struct pcie_ext_cap_vsc_hdr *vsc2 = alloca(sizeof (*vsc2) + 13);
-    struct pcie_ext_cap_vsc_hdr *vsc3 = alloca(sizeof (*vsc3) + 13);
-    struct pcie_ext_cap_vsc_hdr *vsc4 = alloca(sizeof (*vsc4) + 13);
+    struct pcie_ext_cap_vsc_hdr *vsc1 = alloca(sizeof(*vsc1) + 5);
+    struct pcie_ext_cap_vsc_hdr *vsc2 = alloca(sizeof(*vsc2) + 13);
+    struct pcie_ext_cap_vsc_hdr *vsc3 = alloca(sizeof(*vsc3) + 13);
+    struct pcie_ext_cap_vsc_hdr *vsc4 = alloca(sizeof(*vsc4) + 13);
     struct pcie_ext_cap_hdr *hdr;
     size_t expoffsets[] = {
         PCI_CFG_SPACE_SIZE,
-        PCI_CFG_SPACE_SIZE + sizeof (struct dsncap),
-        PCI_CFG_SPACE_SIZE + sizeof (struct dsncap) + sizeof (*vsc1) + 8,
+        PCI_CFG_SPACE_SIZE + sizeof(struct dsncap),
+        PCI_CFG_SPACE_SIZE + sizeof(struct dsncap) + sizeof(*vsc1) + 8,
         512,
         600
     };
@@ -853,7 +853,7 @@ test_pci_ext_caps(void **state __attribute__((unused)))
     vfu_ctx.pci.type = VFU_PCI_TYPE_EXPRESS;
 
     vfu_ctx.reg_info = calloc(VFU_PCI_DEV_NUM_REGIONS,
-                              sizeof (*vfu_ctx.reg_info));
+                              sizeof(*vfu_ctx.reg_info));
 
     vfu_ctx.reg_info[VFU_PCI_DEV_CFG_REGION_IDX].cb = test_pci_ext_caps_region_cb;
     vfu_ctx.reg_info[VFU_PCI_DEV_CFG_REGION_IDX].size = PCI_CFG_SPACE_EXP_SIZE;
@@ -863,16 +863,16 @@ test_pci_ext_caps(void **state __attribute__((unused)))
     dsn.sn_hi = 0x8;
 
     vsc1->hdr.id = PCI_EXT_CAP_ID_VNDR;
-    vsc1->len = sizeof (*vsc1) + 5;
+    vsc1->len = sizeof(*vsc1) + 5;
     memcpy(vsc1->data, "abcde", 5);
     vsc2->hdr.id = PCI_EXT_CAP_ID_VNDR;
-    vsc2->len = sizeof (*vsc2) + 13;
+    vsc2->len = sizeof(*vsc2) + 13;
     memcpy(vsc2->data, "Hello world.", 12);
     vsc3->hdr.id = PCI_EXT_CAP_ID_VNDR;
-    vsc3->len = sizeof (*vsc3) + 13;
+    vsc3->len = sizeof(*vsc3) + 13;
     memcpy(vsc3->data, "Hello world.", 12);
     vsc4->hdr.id = PCI_EXT_CAP_ID_VNDR;
-    vsc4->len = sizeof (*vsc4) + 13;
+    vsc4->len = sizeof(*vsc4) + 13;
     memcpy(vsc4->data, "Hello world.", 12);
 
     offset = vfu_pci_add_capability(&vfu_ctx, 4096, VFU_CAP_FLAG_EXTENDED, &dsn);
@@ -994,12 +994,12 @@ static void
 test_device_get_info(void **state UNUSED)
 {
     vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef };
-    struct vfio_device_info d_in = { .argsz = sizeof (d_in) };
+    struct vfio_device_info d_in = { .argsz = sizeof(d_in) };
     struct vfio_device_info d_out;
 
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof (d_in),
+    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof(d_in),
                                                &d_in, &d_out));
-    assert_int_equal(sizeof (d_out), d_out.argsz);
+    assert_int_equal(sizeof(d_out), d_out.argsz);
     assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET,
                      d_out.flags);
     assert_int_equal(vfu_ctx.nr_regions, d_out.num_regions);
@@ -1014,12 +1014,12 @@ static void
 test_device_get_info_compat(void **state UNUSED)
 {
     vfu_ctx_t vfu_ctx = { .nr_regions = 0xdeadbeef };
-    struct vfio_device_info d_in = { .argsz = sizeof (d_in) + 1 };
+    struct vfio_device_info d_in = { .argsz = sizeof(d_in) + 1 };
     struct vfio_device_info d_out;
 
-    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof (d_in) + 1,
+    assert_int_equal(0, handle_device_get_info(&vfu_ctx, sizeof(d_in) + 1,
                                                &d_in, &d_out));
-    assert_int_equal(sizeof (d_out), d_out.argsz);
+    assert_int_equal(sizeof(d_out), d_out.argsz);
     assert_int_equal(VFIO_DEVICE_FLAGS_PCI | VFIO_DEVICE_FLAGS_RESET,
                      d_out.flags);
     assert_int_equal(vfu_ctx.nr_regions, d_out.num_regions);
@@ -1027,7 +1027,7 @@ test_device_get_info_compat(void **state UNUSED)
 
     /* fewer fields */
     assert_int_equal(-EINVAL,
-                     handle_device_get_info(&vfu_ctx, (sizeof (d_in)) - 1,
+                     handle_device_get_info(&vfu_ctx, (sizeof(d_in)) - 1,
                                             &d_in, &d_out));
 }
 
@@ -1492,9 +1492,9 @@ test_exec_command(UNUSED void **state)
     struct vfio_user_header hdr = {
         .cmd = 0xbeef,
         .flags.type = VFIO_USER_F_TYPE_COMMAND,
-        .msg_size = sizeof hdr + 1
+        .msg_size = sizeof(hdr) + 1
     };
-    size_t size = sizeof hdr;
+    size_t size = sizeof(hdr);
     int fds = 0;
     struct iovec _iovecs = { 0 };
     struct iovec *iovecs = NULL;
@@ -1531,9 +1531,9 @@ test_dirty_pages_without_dma(UNUSED void **state)
         .flags = {
             .type = VFIO_USER_F_TYPE_COMMAND
         },
-        .msg_size = sizeof hdr
+        .msg_size = sizeof(hdr)
     };
-    size_t size = sizeof hdr;
+    size_t size = sizeof(hdr);
     int fds = 0;
     struct iovec _iovecs = { 0 };
     struct iovec *iovecs = NULL;


### PR DESCRIPTION
The most common way we have written this is as "sizeof()"; use this form
consistently.

Signed-off-by: John Levon <john.levon@nutanix.com>
