### PR TITLE
don't use wrong buf offset for responding with PCI caps

### DIFF
--- a/lib/pci.c
+++ b/lib/pci.c
@@ -393,6 +393,7 @@ pci_config_space_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
 
         offset += ret;
         count -= ret;
+        buf += ret;
     }
 
     return offset - start;

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -372,7 +372,7 @@ pci_cap_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count, loff_t offset,
     }
 
     if (!is_write) {
-        memcpy(buf + offset, pci_config_space_ptr(vfu_ctx, offset), count);
+        memcpy(buf, pci_config_space_ptr(vfu_ctx, offset), count);
         return count;
     }
 

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -372,7 +372,7 @@ pci_cap_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count, loff_t offset,
     }
 
     if (!is_write) {
-        memcpy(buf, pci_config_space_ptr(vfu_ctx, offset), count);
+        memcpy(buf + offset, pci_config_space_ptr(vfu_ctx, offset), count);
         return count;
     }
 


### PR DESCRIPTION
Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>