### PR TITLE
fix false positive under valgrind

### DIFF
--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -959,7 +959,7 @@ test_pci_ext_caps(void **state UNUSED)
     assert_int_equal(EINVAL, errno);
 
     offset = vfu_pci_find_next_capability(&vfu_ctx, true,
-                                          expoffsets[1] + 1,
+                                          expoffsets[1] + 8,
                                           PCI_EXT_CAP_ID_DSN);
     assert_int_equal(0, offset);
     assert_int_equal(ENOENT, errno);


### PR DESCRIPTION
valgrind gets confused by a non-aligned pointer load; use an aligned load
so it's quietened.

Signed-off-by: John Levon <john.levon@nutanix.com>
