### PR TITLE
use shared libvfio-user object for gpio sample

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -38,8 +38,9 @@ target_link_libraries(server vfio-user-static ssl crypto)
 add_executable(null null.c)
 target_link_libraries(null vfio-user-static pthread)
 
+LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/lib)
 add_executable(gpio-pci-idio-16 gpio-pci-idio-16.c)
-target_link_libraries(gpio-pci-idio-16 vfio-user-static)
+target_link_libraries(gpio-pci-idio-16 vfio-user)
 
 add_executable(lspci lspci.c)
 target_link_libraries(lspci vfio-user-static)


### PR DESCRIPTION
This makes it easier to test that libvfio-user is correctly installed.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>