### PR TITLE
gpio-pci-idio-16: fix library dependency

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -40,7 +40,7 @@ target_link_libraries(null vfio-user-static pthread)
 
 LINK_DIRECTORIES(${CMAKE_BINARY_DIR}/lib)
 add_executable(gpio-pci-idio-16 gpio-pci-idio-16.c)
-target_link_libraries(gpio-pci-idio-16 vfio-user)
+target_link_libraries(gpio-pci-idio-16 vfio-user-shared)
 
 add_executable(lspci lspci.c)
 target_link_libraries(lspci vfio-user-static)


### PR DESCRIPTION
Normally, target_link_libraries() is sufficient to add a dependency on the
linked library. But, as our CMake target is called "vfio-user-shared", we have
to make this explicit.

This was breaking "make -j" builds.

Reported-by: Karol Latecki <karol.latecki@intel.com>
Signed-off-by: John Levon <john.levon@nutanix.com>
