### PR TITLE
remove vfu_irq_message()

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -508,22 +508,6 @@ int
 vfu_irq_trigger(vfu_ctx_t *vfu_ctx, uint32_t subindex);
 
 /**
- * Sends message to client to trigger an interrupt.
- *
- * libvfio-user takes care of using the IRQ type (INTx, MSI/X), the caller only
- * needs to specify the sub-index.
- * This api can be used to trigger interrupt by sending message to client.
- *
- * @vfu_ctx: the libvfio-user context to trigger interrupt
- * @subindex: vector subindex to trigger interrupt on
- *
- * @returns 0 on success, or -1 on failure. Sets errno.
- */
-
-int
-vfu_irq_message(vfu_ctx_t *vfu_ctx, uint32_t subindex);
-
-/**
  * Takes a guest physical address and returns a list of scatter/gather entries
  * than can be individually mapped in the program's virtual memory.  A single
  * linear guest physical address span may need to be split into multiple

--- a/lib/irq.c
+++ b/lib/irq.c
@@ -419,26 +419,4 @@ vfu_irq_trigger(vfu_ctx_t *vfu_ctx, uint32_t subindex)
     return eventfd_write(vfu_ctx->irqs->efds[subindex], val);
 }
 
-int
-vfu_irq_message(vfu_ctx_t *vfu_ctx, uint32_t subindex)
-{
-    int ret, msg_id = 1;
-    struct vfio_user_irq_info irq_info;
-
-    if (!validate_irq_subindex(vfu_ctx, subindex)) {
-        return ERROR_INT(EINVAL);
-    }
-
-    irq_info.subindex = subindex;
-    ret = vfu_ctx->tran->send_msg(vfu_ctx, msg_id,
-                                  VFIO_USER_VM_INTERRUPT,
-                                  &irq_info, sizeof(irq_info),
-                                  NULL, NULL, 0);
-    if (ret < 0) {
-	    return ERROR_INT(-ret);
-    }
-
-    return 0;
-}
-
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/samples/server.c
+++ b/samples/server.c
@@ -580,15 +580,9 @@ int main(int argc, char *argv[])
         if (ret == -1 && errno == EINTR) {
             if (irq_triggered) {
                 irq_triggered = false;
-                vfu_irq_trigger(vfu_ctx, 0);
-                /*
-                 * Apart from triggering an IRQ via the eventfd, we also
-                 * trigger an IRQ via a message, simply for demonstrating how
-                 * it's done. The client expects this behavior from the server.
-                 */
-                ret = vfu_irq_message(vfu_ctx, 0);
+                ret = vfu_irq_trigger(vfu_ctx, 0);
                 if (ret < 0) {
-                    err(EXIT_FAILURE, "vfu_irq_message() failed");
+                    err(EXIT_FAILURE, "vfu_irq_trigger() failed");
                 }
 
                 /*


### PR DESCRIPTION
This sends a message to a vfio-user client to trigger an IRQ, instead of writing
to an eventfd. However, this isn't necessary on the cases we care about, where
eventfds *are* available. Furthermore, this isn't something an API user should
need to know about: if we ever care, the better way to do this is to make
vfu_irq_trigger() automatically use a message if an eventfd isn't available.

Signed-off-by: John Levon <john.levon@nutanix.com>
