### PR TITLE
fix vfu_ctx_create() error path

### DIFF
--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -848,11 +848,10 @@ tran_sock_detach(vfu_ctx_t *vfu_ctx)
     tran_sock_t *ts;
 
     assert(vfu_ctx != NULL);
-    assert(vfu_ctx->tran_data != NULL);
 
     ts = vfu_ctx->tran_data;
 
-    if (ts->conn_fd != -1) {
+    if (ts != NULL && ts->conn_fd != -1) {
         // FIXME: handle EINTR
         (void) close(ts->conn_fd);
         ts->conn_fd = -1;
@@ -865,11 +864,10 @@ tran_sock_fini(vfu_ctx_t *vfu_ctx)
     tran_sock_t *ts;
 
     assert(vfu_ctx != NULL);
-    assert(vfu_ctx->tran_data != NULL);
 
     ts = vfu_ctx->tran_data;
 
-    if (ts->listen_fd != -1) {
+    if (ts != NULL && ts->listen_fd != -1) {
         // FIXME: handle EINTR
         (void) close(ts->listen_fd);
         ts->listen_fd = -1;


### PR DESCRIPTION
The ->detach() and ->fini() transport handlers can't presume ->tran_data is set,
since we cleanup a failed vfu_create_ctx() with vfu_destroy_ctx().

Signed-off-by: John Levon <john.levon@nutanix.com>
