### PR TITLE
fix teardown of DMA controller 

### DIFF
--- a/lib/private.h
+++ b/lib/private.h
@@ -147,10 +147,6 @@ handle_dma_map_or_unmap(vfu_ctx_t *vfu_ctx, uint32_t size, bool map,
                         int *fds, size_t nr_fds,
                         struct vfio_user_dma_region *dma_regions);
 
-void
-_dma_controller_do_remove_region(dma_controller_t *dma,
-                                 dma_memory_region_t *region);
-
 int
 get_next_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, int *fds,
                  size_t *nr_fds);
@@ -185,6 +181,14 @@ should_exec_command(vfu_ctx_t *vfu_ctx, uint16_t cmd);
 int
 handle_device_set_irqs(vfu_ctx_t *vfu_ctx, uint32_t size,
                        int *fds, size_t nr_fds, struct vfio_irq_set *irq_set);
+
+#ifdef UNIT_TEST
+
+void
+dma_controller_unmap_region(dma_controller_t *dma,
+                            dma_memory_region_t *region);
+
+#endif /* UNIT_TEST */
 
 #endif /* LIB_VFIO_USER_PRIVATE_H */
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -50,8 +50,7 @@ target_link_libraries(unit-tests PUBLIC cmocka json-c)
 target_compile_definitions(unit-tests PUBLIC UNIT_TEST)
 
 # No "target_link_options" in cmake2
-target_link_libraries(unit-tests PUBLIC
-                      "-Wl,--wrap=_dma_controller_do_remove_region")
+target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=dma_controller_unmap_region")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=dma_controller_add_region")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=dma_controller_remove_region")
 target_link_libraries(unit-tests PUBLIC "-Wl,--wrap=dma_map_region")

--- a/test/mocks.c
+++ b/test/mocks.c
@@ -96,7 +96,7 @@ __wrap_dma_map_region(dma_memory_region_t *region, int prot, size_t offset,
 }
 
 void
-__wrap__dma_controller_do_remove_region(dma_controller_t *dma,
+__wrap_dma_controller_unmap_region(dma_controller_t *dma,
                                        dma_memory_region_t *region)
 {
     check_expected(dma);
@@ -286,7 +286,7 @@ static struct function funcs[] = {
     {.addr = &__wrap_dma_controller_add_region},
     {.addr = &__wrap_dma_controller_remove_region},
     {.addr = &__wrap_dma_map_region},
-    {.addr = &__wrap__dma_controller_do_remove_region},
+    {.addr = &__wrap_dma_controller_unmap_region},
     {.addr = &__wrap_device_is_stopped},
     {.addr = &__wrap_get_next_command},
     {.addr = &__wrap_exec_command},

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -357,9 +357,9 @@ test_dma_controller_remove_region_mapped(void **state UNUSED)
     expect_value(mock_unmap_dma, len, 0x100);
     /* FIXME add uni test when unmap_dma fails */
     will_return(mock_unmap_dma, 0);
-    patch(_dma_controller_do_remove_region);
-    expect_value(__wrap__dma_controller_do_remove_region, dma, d);
-    expect_value(__wrap__dma_controller_do_remove_region, region, &d->regions[0]);
+    patch(dma_controller_unmap_region);
+    expect_value(__wrap_dma_controller_unmap_region, dma, d);
+    expect_value(__wrap_dma_controller_unmap_region, region, &d->regions[0]);
     assert_int_equal(0,
         dma_controller_remove_region(d, 0xdeadbeef, 0x100, mock_unmap_dma, &v));
 }
@@ -381,7 +381,7 @@ test_dma_controller_remove_region_unmapped(void **state UNUSED)
     expect_value(mock_unmap_dma, iova, 0xdeadbeef);
     expect_value(mock_unmap_dma, len, 0x100);
     will_return(mock_unmap_dma, 0);
-    patch(_dma_controller_do_remove_region);
+    patch(dma_controller_unmap_region);
     assert_int_equal(0,
         dma_controller_remove_region(d, 0xdeadbeef, 0x100, mock_unmap_dma, &v));
 }


### PR DESCRIPTION
If there are regions remaining when we call dma_controller_destroy(), and one of
those regions is not mmap()ed, we were incorrectly trying to unmap it.

Fix this, and also rename the function so its purpose is clearer.

Signed-off-by: John Levon <john.levon@nutanix.com>
Reported-by: Changpeng Liu <changpeng.liu@intel.com>