### PR TITLE
assert fd != -1 in unmap path

### DIFF
--- a/lib/dma.c
+++ b/lib/dma.c
@@ -105,11 +105,12 @@ _dma_controller_do_remove_region(dma_controller_t *dma,
                region->fd, region->virt_addr,
                region->virt_addr + region->size - 1);
     }
-    if (region->fd != -1) {
-        if (close(region->fd) == -1) {
-            vfu_log(dma->vfu_ctx, LOG_DEBUG,
-                    "failed to close fd %d: %m\n", region->fd);
-        }
+
+    assert(region->fd != -1);
+
+    if (close(region->fd) == -1) {
+        vfu_log(dma->vfu_ctx, LOG_WARNING, "failed to close fd %d: %m\n",
+                region->fd);
     }
 }
 UNIT_TEST_SYMBOL(_dma_controller_do_remove_region);


### PR DESCRIPTION
We shouldn't even be trying to unmap if the region doesn't have an associated
file descriptor.

Signed-off-by: John Levon <john.levon@nutanix.com>
