### PR TITLE
add -Wmissing-declarations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,9 @@ set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb")
 set(CMAKE_C_FLAGS_RELEASE "-O3")
 
 set(CMAKE_C_FLAGS
-    "${CMAKE_C_FLAGS} -Wall -Werror -Wextra -Wno-missing-field-initializers")
+    "${CMAKE_C_FLAGS} -Wall -Werror -Wextra ")
+set(CMAKE_C_FLAGS
+    "${CMAKE_C_FLAGS} -Wno-missing-field-initializers -Wmissing-declarations")
 
 # public headers
 add_subdirectory(include)

--- a/lib/common.h
+++ b/lib/common.h
@@ -58,6 +58,21 @@
 #define UNIT_TEST_SYMBOL(x) \
     typeof(x) __wrap_##x __attribute__((weak, alias(#x)))
 
+#ifdef UNIT_TEST
+
+#define MOCKED(r, f, ...) \
+    r f(__VA_ARGS__); \
+    r __real_ ## f(__VA_ARGS__); \
+    r __wrap_ ## f(__VA_ARGS__);
+
+#else /* UNIT_TEST */
+
+#define MOCKED(r, f, ...) \
+    r f(__VA_ARGS__); \
+    r __wrap_ ## f(__VA_ARGS__)
+
+#endif /* UNIT_TEST */
+
 #endif /* LIB_VFIO_USER_COMMON_H */
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/lib/dma.c
+++ b/lib/dma.c
@@ -42,6 +42,7 @@
 #include <errno.h>
 
 #include "dma.h"
+#include "private.h"
 
 static inline ssize_t
 fd_get_blocksize(int fd)
@@ -113,7 +114,6 @@ _dma_controller_do_remove_region(dma_controller_t *dma,
     }
 }
 UNIT_TEST_SYMBOL(_dma_controller_do_remove_region);
-
 /*
  * FIXME super ugly, but without this functions within the same compilation
  * unit don't call the wrapped version, making unit testing impossible.
@@ -418,7 +418,8 @@ out:
     return cnt;
 }
 
-ssize_t _get_bitmap_size(size_t region_size, size_t pgsize)
+static ssize_t
+get_bitmap_size(size_t region_size, size_t pgsize)
 {
     if (pgsize == 0) {
         return -EINVAL;
@@ -449,7 +450,7 @@ int dma_controller_dirty_page_logging_start(dma_controller_t *dma, size_t pgsize
 
     for (i = 0; i < dma->nregions; i++) {
         dma_memory_region_t *region = &dma->regions[i];
-        ssize_t bitmap_size = _get_bitmap_size(region->size, pgsize);
+        ssize_t bitmap_size = get_bitmap_size(region->size, pgsize);
         if (bitmap_size < 0) {
             return bitmap_size;
         }
@@ -512,7 +513,7 @@ dma_controller_dirty_page_get(dma_controller_t *dma, dma_addr_t addr, int len,
         return -EINVAL;
     }
 
-    bitmap_size = _get_bitmap_size(len, pgsize);
+    bitmap_size = get_bitmap_size(len, pgsize);
     if (bitmap_size < 0) {
         return bitmap_size;
     }

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -116,15 +116,15 @@ dma_controller_destroy(dma_controller_t *dma);
  *   where this region would have been mapped to if the call could succeed
  *   (e.g. due to conflict with existing region).
  */
-int
-dma_controller_add_region(dma_controller_t *dma,
-                          dma_addr_t dma_addr, size_t size,
-                          int fd, off_t offset, uint32_t prot);
+MOCKED(int, dma_controller_add_region, dma_controller_t *dma,
+       dma_addr_t dma_addr, size_t size, int fd, off_t offset, uint32_t prot);
 
-int
-dma_controller_remove_region(dma_controller_t *dma,
-                             dma_addr_t dma_addr, size_t size,
-                             vfu_unmap_dma_cb_t *unmap_dma, void *data);
+MOCKED(void, _dma_controller_do_remove_region, dma_controller_t *dma,
+       dma_memory_region_t *region);
+
+MOCKED(int, dma_controller_remove_region, dma_controller_t *dma,
+       dma_addr_t dma_addr, size_t size, vfu_unmap_dma_cb_t *unmap_dma,
+       void *data);
 
 // Helper for dma_addr_to_sg() slow path.
 int
@@ -250,9 +250,8 @@ dma_addr_to_sg(const dma_controller_t *dma,
     return cnt;
 }
 
-void *
-dma_map_region(dma_memory_region_t *region, int prot,
-               size_t offset, size_t len);
+MOCKED(void *, dma_map_region, dma_memory_region_t *region, int prot,
+       size_t offset, size_t len);
 
 int
 dma_unmap_region(dma_memory_region_t *region, void *virt_addr, size_t len);

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -42,6 +42,7 @@
 #include <stddef.h>
 
 #include "libvfio-user.h"
+#include "private.h"
 
 struct migration *
 init_migration(const vfu_migration_callbacks_t *callbacks,
@@ -54,11 +55,9 @@ migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
 bool
 migration_available(vfu_ctx_t *vfu_ctx);
 
-bool
-device_is_stopped_and_copying(struct migration *migr);
+MOCKED(bool, device_is_stopped, struct migration *migr);
 
-bool
-device_is_stopped(struct migration *migr);
+MOCKED(bool, device_is_stopped_and_copying, struct migration *migration);
 
 size_t
 migration_get_pgsize(struct migration *migr);

--- a/lib/private.h
+++ b/lib/private.h
@@ -147,23 +147,6 @@ handle_dma_map_or_unmap(vfu_ctx_t *vfu_ctx, uint32_t size, bool map,
                         int *fds, size_t nr_fds,
                         struct vfio_user_dma_region *dma_regions);
 
-void
-_dma_controller_do_remove_region(dma_controller_t *dma,
-                                 dma_memory_region_t *region);
-
-int
-get_next_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, int *fds,
-                 size_t *nr_fds);
-
-int
-exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr, size_t size,
-             int *fds, size_t nr_fds, int **fds_out, size_t *nr_fds_out,
-             struct iovec *_iovecs, struct iovec **iovecs, size_t *nr_iovecs,
-             bool *free_iovec_data);
-
-int
-process_request(vfu_ctx_t *vfu_ctx);
-
 int
 consume_fd(int *fds, size_t nr_fds, size_t index);
 
@@ -176,15 +159,27 @@ long
 dev_get_reginfo(vfu_ctx_t *vfu_ctx, uint32_t index, uint32_t argsz,
                 struct vfio_region_info **vfio_reg, int **fds, size_t *nr_fds);
 
-bool
-cmd_allowed_when_stopped_and_copying(uint16_t cmd);
-
-bool
-should_exec_command(vfu_ctx_t *vfu_ctx, uint16_t cmd);
-
 int
 handle_device_set_irqs(vfu_ctx_t *vfu_ctx, uint32_t size,
                        int *fds, size_t nr_fds, struct vfio_irq_set *irq_set);
+
+MOCKED(bool, should_exec_command, vfu_ctx_t *vfu_ctx, uint16_t cmd);
+
+MOCKED(bool, cmd_allowed_when_stopped_and_copying, uint16_t cmd);
+
+MOCKED(int, get_next_command, vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
+       int *fds, size_t *nr_fds);
+
+MOCKED(int, exec_command, vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
+       size_t size, int *fds, size_t nr_fds, int **fds_out, size_t *nr_fds_out,
+       struct iovec *_iovecs, struct iovec **iovecs, size_t *nr_iovecs,
+       bool *free_iovec_data);
+
+MOCKED(int, process_request, vfu_ctx_t *vfu_ctx);
+
+MOCKED(int, handle_dirty_pages, vfu_ctx_t *vfu_ctx, uint32_t size,
+       struct iovec **iovecs, size_t *nr_iovecs,
+       struct vfio_iommu_type1_dirty_bitmap *dirty_bitmap);
 
 #endif /* LIB_VFIO_USER_PRIVATE_H */
 

--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -446,7 +446,7 @@ out:
     return 0;
 }
 
-int
+static int
 tran_sock_get_poll_fd(vfu_ctx_t *vfu_ctx)
 {
     tran_sock_t *ts = vfu_ctx->tran_data;
@@ -537,7 +537,7 @@ out:
     return ret;
 }
 
-int
+static int
 recv_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t *msg_idp,
              struct vfio_user_version **versionp)
 {
@@ -637,7 +637,7 @@ out:
     return ret;
 }
 
-int
+static int
 send_version(vfu_ctx_t *vfu_ctx, int sock, uint16_t msg_id,
              struct vfio_user_version *cversion)
 {

--- a/lib/tran_sock.h
+++ b/lib/tran_sock.h
@@ -60,12 +60,9 @@ tran_parse_version_json(const char *json_str, int *client_max_fdsp,
  * Send a message to the other end.  The iovecs array should leave the first
  * entry empty, as it will be used for the header.
  */
-int
-tran_sock_send_iovec(int sock, uint16_t msg_id, bool is_reply,
-                     enum vfio_user_command cmd,
-                     struct iovec *iovecs, size_t nr_iovecs,
-                     int *fds, int count,
-                     int err);
+MOCKED(int, tran_sock_send_iovec, int sock, uint16_t msg_id, bool is_reply,
+       enum vfio_user_command cmd, struct iovec *iovecs, size_t nr_iovecs,
+       int *fds, int count, int err);
 
 /*
  * Send a message to the other end with the given data.

--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -55,7 +55,7 @@ _log(vfu_ctx_t *vfu_ctx UNUSED, UNUSED int level, char const *msg)
 static int pin;
 bool dirty = true;
 
-ssize_t
+static ssize_t
 bar2_access(vfu_ctx_t *vfu_ctx UNUSED, char * const buf,
             size_t count, loff_t offset, const bool is_write)
 {

--- a/samples/server.c
+++ b/samples/server.c
@@ -86,7 +86,7 @@ arm_timer(vfu_ctx_t *vfu_ctx, time_t t)
     return 0;
 }
 
-ssize_t
+static ssize_t
 bar0_access(vfu_ctx_t *vfu_ctx, char * const buf, size_t count, loff_t offset,
             const bool is_write)
 {
@@ -115,7 +115,7 @@ bar0_access(vfu_ctx_t *vfu_ctx, char * const buf, size_t count, loff_t offset,
     return count;
 }
 
-ssize_t
+static ssize_t
 bar1_access(vfu_ctx_t *vfu_ctx, char * const buf,
             size_t count, loff_t offset,
             const bool is_write)
@@ -190,7 +190,8 @@ unmap_dma(vfu_ctx_t *vfu_ctx, uint64_t iova, uint64_t len)
     return -EINVAL;
 }
 
-void get_md5sum(unsigned char *buf, int len, unsigned char *md5sum)
+static void
+get_md5sum(unsigned char *buf, int len, unsigned char *md5sum)
 {
 	MD5_CTX ctx;
 
@@ -401,14 +402,16 @@ migration_data_written(UNUSED vfu_ctx_t *vfu_ctx, UNUSED __u64 count)
     return 0;
 }
 
-size_t
+static size_t
 nr_pages(size_t size)
 {
-    return (size / sysconf(_SC_PAGE_SIZE) + (size % sysconf(_SC_PAGE_SIZE) > 1));
+    return (size / sysconf(_SC_PAGE_SIZE) +
+            (size % sysconf(_SC_PAGE_SIZE) > 1));
 }
 
-size_t
-page_align(size_t size) {
+static size_t
+page_align(size_t size)
+{
     return  nr_pages(size) * sysconf(_SC_PAGE_SIZE);
 }
 

--- a/test/mocks.c
+++ b/test/mocks.c
@@ -40,6 +40,7 @@
 #include "dma.h"
 #include "migration.h"
 #include "../lib/private.h"
+#include "../lib/tran_sock.h"
 
 struct function
 {
@@ -126,9 +127,10 @@ __wrap_get_next_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
 
 int
 __wrap_exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
-                    size_t size, int *fds, size_t *nr_fds, size_t **fds_out,
-                    int *nr_fds_out, struct iovec *_iovecs, struct iovec **iovecs,
-                    size_t *nr_iovecs, bool *free_iovec_data)
+                    size_t size, int *fds, size_t nr_fds, int **fds_out,
+                    size_t *nr_fds_out, struct iovec *_iovecs,
+                    struct iovec **iovecs, size_t *nr_iovecs,
+                    bool *free_iovec_data)
 {
     if (!is_patched(exec_command)) {
         return __real_exec_command(vfu_ctx, hdr, size, fds, nr_fds, fds_out,
@@ -230,16 +232,6 @@ __wrap_cmd_allowed_when_stopped_and_copying(uint16_t cmd)
         return __real_cmd_allowed_when_stopped_and_copying(cmd);
     }
     check_expected(cmd);
-    return mock();
-}
-
-bool
-__wrap_cmd_allowed_when_stopped(struct migration *migration)
-{
-    if (!is_patched(device_is_stopped)) {
-        return __real_device_is_stopped(migration);
-    }
-    check_expected(migration);
     return mock();
 }
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -29,6 +29,8 @@
  */
 
 #include <stdbool.h>
+#include <sys/socket.h>
+
 #include "private.h"
 
 void unpatch_all(void);
@@ -37,51 +39,13 @@ void patch(void *fn);
 
 bool is_patched(void *fn);
 
-bool
-__real_cmd_allowed_when_stopped_and_copying(u_int16_t cmd);
+MOCKED(int, close, int fd);
 
-int
-handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
-                   struct iovec **iovecs, size_t *nr_iovecs,
-                   struct vfio_iommu_type1_dirty_bitmap *dirty_bitmap);
+MOCKED(void, free, void *);
 
-int
-__real_handle_dirty_pages(vfu_ctx_t *vfu_ctx, uint32_t size,
-                          struct iovec **iovecs, size_t *nr_iovecs,
-                          struct vfio_iommu_type1_dirty_bitmap *dirty_bitmap);
+MOCKED(int, bind, int sockfd, const struct sockaddr *addr, socklen_t addrlen);
 
-int
-__real_dma_controller_add_region(dma_controller_t *dma, dma_addr_t dma_addr,
-                                 size_t size, int fd, off_t offset,
-                                 uint32_t prot);
-
-int
-__real_dma_controller_remove_region(dma_controller_t *dma,
-                                    dma_addr_t dma_addr, size_t size,
-                                    vfu_unmap_dma_cb_t *unmap_dma, void *data);
-
-bool
-__real_device_is_stopped(struct migration *migr);
-
-int
-__real_exec_command(vfu_ctx_t *vfu_ctx, struct vfio_user_header *hdr,
-                    size_t size, int *fds, size_t *nr_fds, size_t **fds_out,
-                    int *nr_fds_out, struct iovec *_iovecs, struct iovec **iovecs,
-                    size_t *nr_iovecs, bool *free_iovec_data);
-int
-__real_close(int fd);
-
-void
-__real_free(void *ptr);
-
-int
-__real_process_request(vfu_ctx_t *vfu_ctx);
-
-bool
-__real_device_is_stopped_and_copying(struct migration *migration);
-
-bool
-__real_should_exec_command(vfu_ctx_t *vfu_ctx, uint16_t cmd);
+MOCKED(int, listen, int sockfd, int backlog);
 
 int
 mock_unmap_dma(vfu_ctx_t *vfu_ctx, uint64_t iova, uint64_t len);

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -1600,8 +1600,9 @@ test_should_exec_command(UNUSED void **state)
     assert_true(should_exec_command(&vfu_ctx, 0xbeef));
 }
 
-int recv_body(UNUSED vfu_ctx_t *vfu_ctx, UNUSED const struct vfio_user_header *hdr,
-              UNUSED void **datap)
+static int
+recv_body(UNUSED vfu_ctx_t *vfu_ctx, UNUSED const struct vfio_user_header *hdr,
+          UNUSED void **datap)
 {
     /* hack to avoid having to refactor the rest of exec_command */
     return -1;


### PR DESCRIPTION
This is used by SPDK, and it's generally useful. This also uncovered some issues
in the test mocking.

Signed-off-by: John Levon <john.levon@nutanix.com>
