### PR TITLE
check for double attach

### DIFF
--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -719,6 +719,13 @@ tran_sock_attach(vfu_ctx_t *vfu_ctx)
 
     ts = vfu_ctx->tran_data;
 
+    if (ts->conn_fd != -1) {
+        vfu_log(vfu_ctx, LOG_ERR, "%s: already attached with fd=%d",
+                __func__, ts->conn_fd);
+        errno = EINVAL;
+        return -1;
+    }
+
     ts->conn_fd = accept(ts->listen_fd, NULL, NULL);
     if (ts->conn_fd == -1) {
         return -1;


### PR DESCRIPTION
As seen in https://github.com/spdk/spdk/issues/1854, we should explicitly check
for attaching an already-attached context, instead of silently over-writing the
existing socket fd.

Signed-off-by: John Levon <john.levon@nutanix.com>
