### PR TITLE
Fix compiler error comparison is always true

### DIFF
--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -141,7 +141,7 @@ main(int argc, char *argv[])
 {
     int ret;
     bool verbose = false;
-    char opt;
+    int opt;
     struct sigaction act = { .sa_handler = _sa_handler };
     vfu_ctx_t *vfu_ctx;
     size_t migr_regs_size = vfu_get_migr_register_area_size();

--- a/samples/server.c
+++ b/samples/server.c
@@ -418,7 +418,7 @@ int main(int argc, char *argv[])
 {
     int ret;
     bool verbose = false;
-    char opt;
+    int opt;
     struct sigaction act = {.sa_handler = _sa_handler};
     const size_t bar1_size = 0x3000;
     size_t migr_regs_size, migr_data_size, migr_size;


### PR DESCRIPTION
Changed variable type for getopt() to fix compiler warning when
compiling on arm

This patch fixes this error: 
/libvfio-user/samples/gpio-pci-idio-16.c: In function ‘main’:
/libvfio-user/samples/gpio-pci-idio-16.c:160:44: error: comparison is always true due to limited range of data type [-Werror=type-limits]
  160 |     while ((opt = getopt(argc, argv, "v")) != -1) {
      |                                            ^~
cc1: all warnings being treated as errors

Seen when building on arm with gcc (Ubuntu 9.3.0-17ubuntu1~20.04) 9.3.0