### PR TITLE
enforce linear, squashed history in master branch

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -38,11 +38,11 @@ repository:
 
   # Either `true` to allow merging pull requests with a merge commit, or `false`
   # to prevent merging pull requests with merge commits.
-  allow_merge_commit: true
+  allow_merge_commit: false
 
   # Either `true` to allow rebase-merging pull requests, or `false` to prevent
   # rebase-merging.
-  allow_rebase_merge: true
+  allow_rebase_merge: false
 
 # Labels: define labels for Issues and Pull Requests
 #labels:


### PR DESCRIPTION
Due to the CI infrastructure, the logical unit of "keeping the master branch
green" is individual PRs (tests can't be run on intra-PR commits). Therefore, we
need to enforce that PRs are squashed to a single commit when pushing to master,
which also helps keep a clean, meaningful history.

Signed-off-by: John Levon <john.levon@nutanix.com>