### PR TITLE
align number of bytes for dirty page bitmap to QWORD

### DIFF
--- a/lib/dma.c
+++ b/lib/dma.c
@@ -423,7 +423,7 @@ get_bitmap_size(size_t region_size, size_t pgsize)
         return ERROR_INT(EINVAL);
     }
     size_t nr_pages = (region_size / pgsize) + (region_size % pgsize != 0);
-    return (nr_pages / CHAR_BIT) + (nr_pages % CHAR_BIT != 0);
+    return ROUND_UP(nr_pages, sizeof(uint64_t) * CHAR_BIT) / CHAR_BIT;
 }
 
 int dma_controller_dirty_page_logging_start(dma_controller_t *dma, size_t pgsize)

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -1226,7 +1226,7 @@ test_dma_controller_dirty_page_get(void **state UNUSED)
 {
     dma_memory_region_t *r;
     uint64_t len = UINT32_MAX + (uint64_t)10;
-    char bp[131073];
+    char bp[0x20008]; /* must be QWORD aligned */
 
     vfu_ctx.dma->nregions = 1;
     r = &vfu_ctx.dma->regions[0];
@@ -1236,7 +1236,7 @@ test_dma_controller_dirty_page_get(void **state UNUSED)
     vfu_ctx.dma->dirty_pgsize = 4096;
 
     assert_int_equal(0, dma_controller_dirty_page_get(vfu_ctx.dma, (void *)0,
-                     len, 4096, 131073, (char **)&bp));
+                     len, 4096, sizeof(bp), (char **)&bp));
 }
 
 int


### PR DESCRIPTION
This is how QEMU operates.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>
Reviewed-by: John Levon <john.levon@nutanix.com>