### PR TITLE
allow transitioning from stopped/stop-and-copy state to running state

### DIFF
--- a/lib/migration_priv.h
+++ b/lib/migration_priv.h
@@ -75,7 +75,9 @@ struct migr_state_data {
 /* valid migration state transitions */
 static const struct migr_state_data migr_states[(VFIO_DEVICE_STATE_MASK + 1)] = {
     [VFIO_DEVICE_STATE_STOP] = {
-        .state = 1 << VFIO_DEVICE_STATE_STOP,
+        .state =
+            (1 << VFIO_DEVICE_STATE_STOP) |
+            (1 << VFIO_DEVICE_STATE_RUNNING),
         .name = "stopped"
     },
     [VFIO_DEVICE_STATE_RUNNING] = {
@@ -91,6 +93,7 @@ static const struct migr_state_data migr_states[(VFIO_DEVICE_STATE_MASK + 1)] = 
     [VFIO_DEVICE_STATE_SAVING] = {
         .state =
             (1 << VFIO_DEVICE_STATE_STOP) |
+            (1 << VFIO_DEVICE_STATE_RUNNING) |
             (1 << VFIO_DEVICE_STATE_SAVING) |
             (1 << VFIO_DEVICE_STATE_ERROR),
         .name = "stop-and-copy"

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -845,9 +845,10 @@ test_migration_state_transitions(void **state UNUSED)
     bool (*f)(uint32_t, uint32_t) = vfio_migr_state_transition_is_valid;
     uint32_t i, j;
 
-    /* from stopped (000b): all transitions are invalid */
+    /* from stopped (000b): all transitions are invalid except to running */
     assert_true(f(0, 0));
-    for (i = 1; i < 8; i++) {
+    assert_true(f(0, 1));
+    for (i = 2; i < 8; i++) {
         assert_false(f(0, i));
     }
 
@@ -863,7 +864,7 @@ test_migration_state_transitions(void **state UNUSED)
 
     /* from stop-and-copy (010b) */
     assert_true(f(2, 0));
-    assert_false(f(2, 1));
+    assert_true(f(2, 1));
     assert_true(f(2, 2));
     assert_false(f(2, 3));
     assert_false(f(2, 4));
@@ -1107,28 +1108,30 @@ test_should_exec_command(UNUSED void **state)
     patch("cmd_allowed_when_stopped_and_copying");
     patch("device_is_stopped");
 
-    /* XXX stopped and copying, command allowed */
+    /* TEST stopped and copying, command allowed */
     will_return(device_is_stopped_and_copying, true);
     expect_value(device_is_stopped_and_copying, migration, &migration);
     will_return(cmd_allowed_when_stopped_and_copying, true);
     expect_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
     assert_true(should_exec_command(&vfu_ctx, 0xbeef));
 
-    /* XXX stopped and copying, command not allowed */
+    /* TEST stopped and copying, command not allowed */
     will_return(device_is_stopped_and_copying, true);
     expect_any(device_is_stopped_and_copying, migration);
     will_return(cmd_allowed_when_stopped_and_copying, false);
     expect_any(cmd_allowed_when_stopped_and_copying, cmd);
     assert_false(should_exec_command(&vfu_ctx, 0xbeef));
 
-    /* XXX stopped */
+    /* TEST stopped */
     will_return(device_is_stopped_and_copying, false);
     expect_any(device_is_stopped_and_copying, migration);
     will_return(device_is_stopped, true);
     expect_value(device_is_stopped, migration, &migration);
+    will_return(cmd_allowed_when_stopped_and_copying, false);
+    expect_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
     assert_false(should_exec_command(&vfu_ctx, 0xbeef));
 
-    /* XXX none of the above */
+    /* TEST none of the above */
     will_return(device_is_stopped_and_copying, false);
     expect_any(device_is_stopped_and_copying, migration);
     will_return(device_is_stopped, false);


### PR DESCRIPTION
If the destination fails at the last state of migration then QEMU
attempts to continue running on the source.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>
Reviewed-by: John Levon <john.levon@nutanix.com>