### PR TITLE
Handle support of PCI FLR capability

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -317,12 +317,18 @@ typedef enum vfu_reset_type {
      * reset to a known-good initial state (including any PCI register state).
      */
     VFU_RESET_DEVICE,
+
     /*
      * The vfio-user socket client connection was closed or reset. The attached
      * context is cleaned up after returning from the reset callback, and
      * vfu_attach_ctx() must be called to establish a new client.
      */
-    VFU_RESET_LOST_CONN
+    VFU_RESET_LOST_CONN,
+
+    /*
+     * Client requested to initiate PCI function level reset.
+     */
+    VFU_RESET_PCI_FLR
 } vfu_reset_type_t;
 
 /*

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -276,14 +276,17 @@ handle_px_pxdc_write(vfu_ctx_t *vfu_ctx, struct pxcap *px,
         vfu_log(vfu_ctx, LOG_DEBUG, "MRRS set to %d", p->mrrs);
     }
 
-    if (p->iflr && vfu_ctx->reset) {
+    if (p->iflr) {
         if (px->pxdcap.flrc == 0) {
-            vfu_log(vfu_ctx, LOG_ERR, "FLR capability is not supported\n");
+            vfu_log(vfu_ctx, LOG_ERR, "FLR capability is not supported");
             return ERROR_INT(EINVAL);
         }
-        vfu_log(vfu_ctx, LOG_DEBUG,
-            "initiate function level reset");
-        return vfu_ctx->reset(vfu_ctx, VFU_RESET_PCI_FLR);
+        if (vfu_ctx->reset != NULL) {
+            vfu_log(vfu_ctx, LOG_DEBUG, "initiate function level reset");
+            return vfu_ctx->reset(vfu_ctx, VFU_RESET_PCI_FLR);
+        } else {
+            vfu_log(vfu_ctx, LOG_ERR, "FLR callback is not implemented");
+        }
     }
 
     return 0;

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -276,9 +276,14 @@ handle_px_pxdc_write(vfu_ctx_t *vfu_ctx, struct pxcap *px,
         vfu_log(vfu_ctx, LOG_DEBUG, "MRRS set to %d", p->mrrs);
     }
 
-    if (p->iflr) {
+    if (p->iflr && vfu_ctx->reset) {
+        if (px->pxdcap.flrc == 0) {
+            vfu_log(vfu_ctx, LOG_ERR, "FLR capability is not supported\n");
+            return ERROR_INT(EINVAL);
+        }
         vfu_log(vfu_ctx, LOG_DEBUG,
             "initiate function level reset");
+        return vfu_ctx->reset(vfu_ctx, VFU_RESET_PCI_FLR);
     }
 
     return 0;

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -58,6 +58,7 @@ PCI_CAP_LIST_NEXT = 1
 
 PCI_CAP_ID_PM = 0x1
 PCI_CAP_ID_VNDR = 0x9
+PCI_CAP_ID_EXP = 0x10
 
 PCI_EXT_CAP_ID_DSN = 0x03
 PCI_EXT_CAP_ID_VNDR = 0x0b
@@ -151,6 +152,11 @@ VFU_DEV_ERR_IRQ  = 3
 VFU_DEV_REQ_IRQ  = 4
 VFU_DEV_NUM_IRQS = 5
 
+# enum vfu_reset_type
+VFU_RESET_DEVICE = 0
+VFU_RESET_LOST_CONN = 1
+VFU_RESET_PCI_FLR = 2
+
 # vfu_pci_type_t
 VFU_PCI_TYPE_CONVENTIONAL = 0
 VFU_PCI_TYPE_PCI_X_1      = 1
@@ -234,6 +240,8 @@ vfu_region_access_cb_t = c.CFUNCTYPE(c.c_int, c.c_void_p, c.POINTER(c.c_char),
 lib.vfu_setup_region.argtypes = (c.c_void_p, c.c_int, c.c_ulong,
                                  vfu_region_access_cb_t, c.c_int, c.c_void_p,
                                  c.c_uint32, c.c_int, c.c_ulong)
+vfu_reset_cb_t = c.CFUNCTYPE(c.c_int, c.c_void_p, c.c_int)
+lib.vfu_setup_device_reset_cb.argtypes = (c.c_void_p, vfu_reset_cb_t)
 lib.vfu_pci_get_config_space.argtypes = (c.c_void_p,)
 lib.vfu_pci_get_config_space.restype = (c.c_void_p)
 lib.vfu_setup_device_nr_irqs.argtypes = (c.c_void_p, c.c_int, c.c_uint32)
@@ -448,6 +456,10 @@ def vfu_setup_region(ctx, index, size, cb=None, flags=0,
                                c.cast(cb, vfu_region_access_cb_t),
                                flags, c_mmap_areas, nr_mmap_areas, fd, offset)
     return ret
+
+def vfu_setup_device_reset_cb(ctx, cb):
+    assert ctx != None
+    return lib.vfu_setup_device_reset_cb(ctx, c.cast(cb, vfu_reset_cb_t))
 
 def vfu_setup_device_nr_irqs(ctx, irqtype, count):
     assert ctx != None

--- a/test/py/test_pci_caps.py
+++ b/test/py/test_pci_caps.py
@@ -294,9 +294,12 @@ def test_pci_cap_write_pmcs():
 
     disconnect_client(ctx, sock)
 
+reset_flag = -1
 @c.CFUNCTYPE(c.c_int, c.c_void_p, c.c_int)
 def vfu_reset_cb(ctx, reset_type):
     assert reset_type == VFU_RESET_PCI_FLR or reset_type == VFU_RESET_LOST_CONN
+    global reset_flag
+    reset_flag = reset_type
     return 0
 
 def test_pci_cap_write_px():
@@ -315,8 +318,10 @@ def test_pci_cap_write_px():
     data=b'\x00\x80'
     write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data)
+    assert reset_flag == VFU_RESET_PCI_FLR
 
     disconnect_client(ctx, sock)
+    assert reset_flag == VFU_RESET_LOST_CONN
 
 def test_pci_cap_write_msix():
     # FIXME

--- a/test/py/test_pci_caps.py
+++ b/test/py/test_pci_caps.py
@@ -315,7 +315,7 @@ def test_pci_cap_write_px():
 
     #iflr
     offset = cap_offsets[5] + 8
-    data=b'\x00\x80'
+    data = b'\x00\x80'
     write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data)
     assert reset_flag == VFU_RESET_PCI_FLR

--- a/test/py/test_pci_caps.py
+++ b/test/py/test_pci_caps.py
@@ -314,7 +314,7 @@ def test_pci_cap_write_px():
     assert pos == cap_offsets[5]
 
     #iflr
-    offset=cap_offsets[5] + 8
+    offset = cap_offsets[5] + 8
     data=b'\x00\x80'
     write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data)


### PR DESCRIPTION
If device supports FLR cap then call vfu_reset_cb_t when FLR is
initiated by client.

Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>