### PR TITLE
Fix struct pxcap

### DIFF
--- a/include/pci_caps/px.h
+++ b/include/pci_caps/px.h
@@ -58,12 +58,13 @@ struct pxdcap {
     uint32_t etfs:1;
     uint32_t l0sl:3;
     uint32_t l1l:3;
-    uint32_t per:1;
-    uint32_t res1:2;
+    uint32_t res1:3;
+    uint32_t rer:1;
+    uint32_t res2:2;
     uint32_t csplv:8;
     uint32_t cspls:2;
     uint32_t flrc:1;
-    uint32_t res2:3;
+    uint32_t res3:3;
 } __attribute__((packed));
 _Static_assert(sizeof(struct pxdcap) == 0x4, "bad PXDCAP size");
 

--- a/samples/lspci.c
+++ b/samples/lspci.c
@@ -50,7 +50,10 @@ int main(void)
                           .sn_hi = 0xcafebabe };
     struct pmcap pm = { .hdr.id = PCI_CAP_ID_PM, .pmcs.nsfrst = 0x1 };
     /* Required for lspci to report extended caps. */
-    struct pxcap px = { .hdr.id = PCI_CAP_ID_EXP };
+    struct pxcap px = {
+            .hdr.id = PCI_CAP_ID_EXP,
+            .pxdcap = {.flrc = 0x1}
+    };
 
     vfu_ctx_t *vfu_ctx = vfu_create_ctx(VFU_TRANS_SOCK, "",
                                         LIBVFIO_USER_FLAG_ATTACH_NB, NULL,

--- a/test/lspci.expected.out.1
+++ b/test/lspci.expected.out.1
@@ -13,9 +13,9 @@
 	Capabilities: [48] Vendor Specific Information: Len=10 <?>
 	Capabilities: [58] Express (v0) Endpoint, MSI 00
 		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
-			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset- SlotPowerLimit 0.000W
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset+ SlotPowerLimit 0.000W
 		DevCtl:	Report errors: Correctable- Non-Fatal- Fatal- Unsupported-
-			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop-
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop- FLReset-
 			MaxPayload 128 bytes, MaxReadReq 128 bytes
 		DevSta:	CorrErr- UncorrErr- FatalErr- UnsuppReq- AuxPwr- TransPend-
 		LnkCap:	Port #0, Speed unknown, Width x0, ASPM not supported, Exit Latency L0s <64ns, L1 <1us

--- a/test/lspci.expected.out.2
+++ b/test/lspci.expected.out.2
@@ -13,9 +13,9 @@
 	Capabilities: [48] Vendor Specific Information: Len=10 <?>
 	Capabilities: [58] Express (v0) Endpoint, MSI 00
 		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
-			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset- SlotPowerLimit 0.000W
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset+ SlotPowerLimit 0.000W
 		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
-			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop-
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop- FLReset-
 			MaxPayload 128 bytes, MaxReadReq 128 bytes
 		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
 		LnkCap:	Port #0, Speed unknown, Width x0, ASPM not supported

--- a/test/lspci.expected.out.3
+++ b/test/lspci.expected.out.3
@@ -13,9 +13,9 @@
 	Capabilities: [48] Vendor Specific Information: Len=10 <?>
 	Capabilities: [58] Express (v0) Endpoint, MSI 00
 		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
-			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset- SlotPowerLimit 0.000W
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset+ SlotPowerLimit 0.000W
 		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
-			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop-
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop- FLReset-
 			MaxPayload 128 bytes, MaxReadReq 128 bytes
 		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
 		LnkCap:	Port #0, Speed unknown, Width x0, ASPM not supported

--- a/test/py/test_pci_caps.py
+++ b/test/py/test_pci_caps.py
@@ -309,7 +309,7 @@ def test_pci_cap_write_px():
 
     #flrc
     cap = struct.pack("ccHHcc52c", to_byte(PCI_CAP_ID_EXP), b'\0', 0, 0, b'\0',
-                      b'\x02', *[b'\0' for _ in range(52)])
+                      b'\x10', *[b'\0' for _ in range(52)])
     pos = vfu_pci_add_capability(ctx, pos=cap_offsets[5], flags=0, data=cap)
     assert pos == cap_offsets[5]
 


### PR DESCRIPTION
* Added missing reserved bits and renamed per to rer nameing as the
  nvme specs
* Add pxcap capability in lspci test

Fixes #524 
Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>