### PR TITLE
Fix make CFLAGS="-DNDEBUG" failure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,6 +147,9 @@ realclean:
 	rm -rf $(GCOVS)
 
 $(BUILD_DIR)/Makefile:
+ifneq (,$(filter -DNDEBUG,$(CFLAGS)))
+	$(error -DNDEBUG flag is not supported)
+endif
 	mkdir -p $(BUILD_DIR)
 	cd $(BUILD_DIR); $(CMAKE) \
 		-D "CMAKE_C_COMPILER:STRING=$(CC)" \


### PR DESCRIPTION
Redefining NDEBUG in files where assert.h is included to prevent build fail due to -DNDEBUG flag
Fix for #341 issue
Signed-off-by: Ivan Efremov <i350300800e@gmail.com>