### PR TITLE
add VFU_REGION_FLAG_ALWAYS_CB to receive callback always

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -221,6 +221,7 @@ typedef ssize_t (vfu_region_access_cb_t)(vfu_ctx_t *vfu_ctx, char *buf,
 #define VFU_REGION_FLAG_WRITE   (1 << 1)
 #define VFU_REGION_FLAG_RW      (VFU_REGION_FLAG_READ | VFU_REGION_FLAG_WRITE)
 #define VFU_REGION_FLAG_MEM     (1 << 2)    // if unset, bar is IO
+#define VFU_REGION_FLAG_ALWAYS_CB   (1 << 3)
 
 /**
  * Set up a device region.

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -208,7 +208,8 @@ region_access(vfu_ctx_t *vfu_ctx, size_t region_index, char *buf,
         dump_buffer("buffer write", buf, count);
     }
 
-    if (region_index == VFU_PCI_DEV_CFG_REGION_IDX) {
+    if ((region_index == VFU_PCI_DEV_CFG_REGION_IDX) &&
+        !(vfu_ctx->reg_info[region_index].flags & VFU_REGION_FLAG_ALWAYS_CB)) {
         ret = pci_config_space_access(vfu_ctx, buf, count, offset, is_write);
         if (ret == -1) {
             return ret;
@@ -1445,7 +1446,7 @@ vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
      * PCI config space is never mappable or of type mem.
      */
     if (region_idx == VFU_PCI_DEV_CFG_REGION_IDX &&
-        flags != VFU_REGION_FLAG_RW) {
+        !(flags & VFU_REGION_FLAG_RW)) {
         return ERROR_INT(EINVAL);
     }
 


### PR DESCRIPTION
Adds VFU_REGION_FLAG_ALWAYS_CB flag which always invokes a
callback for region accesses

Signed-off-by: Jagannathan Raman <jag.raman@oracle.com>