### PR TITLE
VFIO_USER_DEVICE_GET_REGION_IO_FDS fix

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -576,6 +576,12 @@ handle_device_get_region_io_fds(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
 
     vfu_reg = &vfu_ctx->reg_info[req->index];
 
+    // Use flags to detect if the region is set up
+    if ((vfu_reg->flags & ~(VFU_REGION_FLAG_MASK)) ||
+        (!(vfu_reg->flags & VFU_REGION_FLAG_RW))) {
+        return ERROR_INT(EINVAL);
+    }
+
     LIST_FOREACH(sub_reg, &vfu_reg->subregions, entry) {
         nr_sub_reg++;
     }

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -558,7 +558,7 @@ handle_device_get_region_io_fds(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     assert(msg != NULL);
     assert(msg->out_fds == NULL);
 
-    if (msg->in_size != sizeof(vfio_user_region_io_fds_request_t)) {
+    if (msg->in_size < sizeof(vfio_user_region_io_fds_request_t)) {
         return ERROR_INT(EINVAL);
     }
 
@@ -575,10 +575,6 @@ handle_device_get_region_io_fds(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     }
 
     vfu_reg = &vfu_ctx->reg_info[req->index];
-
-    if (vfu_reg->fd == -1) {
-        return ERROR_INT(EINVAL);
-    }
 
     LIST_FOREACH(sub_reg, &vfu_reg->subregions, entry) {
         nr_sub_reg++;

--- a/test/py/test_device_get_region_io_fds.py
+++ b/test/py/test_device_get_region_io_fds.py
@@ -66,6 +66,13 @@ def test_device_get_region_io_fds_setup():
                            mmap_areas=mmap_areas, fd=f.fileno(), offset=0x8000)
     assert ret == 0
 
+    mmap_areas = []
+
+    ret = vfu_setup_region(ctx, index=VFU_PCI_DEV_BAR5_REGION_IDX, size=0x8000,
+                           flags=(VFU_REGION_FLAG_RW),
+                           mmap_areas=mmap_areas, fd=-1, offset=0x8000)
+    assert ret == 0
+
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
@@ -136,7 +143,15 @@ def test_device_get_region_io_fds_no_regions_setup():
                                 index = VFU_PCI_DEV_BAR3_REGION_IDX, count = 0)
 
     ret = msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-              expect=errno.EINVAL)
+              expect = 0)
+
+def test_device_get_region_io_fds_fd_not_setup():
+
+    payload = vfio_user_region_io_fds_request(argsz = 512, flags = 0,
+                                index = VFU_PCI_DEV_BAR5_REGION_IDX, count = 0)
+
+    ret = msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
+              expect = 0)
 
 def test_device_get_region_io_fds_region_out_of_range():
 

--- a/test/py/test_device_get_region_io_fds.py
+++ b/test/py/test_device_get_region_io_fds.py
@@ -143,7 +143,7 @@ def test_device_get_region_io_fds_no_regions_setup():
                                 index = VFU_PCI_DEV_BAR3_REGION_IDX, count = 0)
 
     ret = msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-              expect = 0)
+              expect = errno.EINVAL)
 
 def test_device_get_region_io_fds_fd_not_setup():
 


### PR DESCRIPTION
Fixes 2 issues where VFIO_USER_DEVICE_GET_REGION_IO_FDS fails on regions with an fd of -1 and following a patch for that allowing commands on unset up regions.

Both issues are fixed by this patch