### PR TITLE
enable options in Valgrind that improve tracking uninit values

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,7 +2,7 @@ name: pull_request
 on: pull_request
 jobs:
   ubuntu-20:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
@@ -13,7 +13,7 @@ jobs:
                                   python3-pytest debianutils flake8
           make pre-push VERBOSE=1
   ubuntu-18:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
@@ -25,7 +25,7 @@ jobs:
                                   python3-pytest debianutils
           make pre-push VERBOSE=1
   centos-7:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     container: centos:7
     steps:
@@ -38,7 +38,7 @@ jobs:
               openssl-devel valgrind python36-pytest which
           make pre-push VERBOSE=1
   fedora-34:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     container: fedora
     steps:

--- a/samples/client.c
+++ b/samples/client.c
@@ -1250,12 +1250,12 @@ int main(int argc, char *argv[])
     }
 
     /*
-     * Schedule an interrupt in 3 seconds from now in the old server and then
+     * Schedule an interrupt in 10 seconds from now in the old server and then
      * immediatelly migrate the device. The new server should deliver the
-     * interrupt. Hopefully 3 seconds should be enough for migration to finish.
+     * interrupt. Hopefully 10 seconds should be enough for migration to finish.
      * TODO make this value a command line option.
      */
-    t = time(NULL) + 3;
+    t = time(NULL) + 10;
     ret = access_region(sock, VFU_PCI_DEV_BAR0_REGION_IDX, true, 0, &t, sizeof(t));
     if (ret < 0) {
         err(EXIT_FAILURE, "failed to write to BAR0");

--- a/test/test-client-server.sh
+++ b/test/test-client-server.sh
@@ -8,7 +8,7 @@ set -e
 if [ "$WITH_ASAN" = 1 ]; then
     valgrind=""
 else
-    valgrind="valgrind --quiet --trace-children=yes --error-exitcode=1 --leak-check=full"
+    valgrind="valgrind --quiet --trace-children=yes --error-exitcode=1 --leak-check=full --read-inline-info=yes --read-var-info=yes --track-origins=yes"
 fi
 
 sock="/tmp/vfio-user.sock"


### PR DESCRIPTION
These extra options make tracking uninitilized values easier. They make
Valgrind run slower so we need to increase the timeouts in the CI.

Signed-off-by: Thanos Makatos <thanos.makatos@nutanix.com>