### PR TITLE
Fix reply of VFIO_USER_DEVICE_GET_REGION_INFO

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -405,6 +405,7 @@ handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     struct vfio_region_info *out_info;
     vfu_reg_info_t *vfu_reg;
     size_t caps_size = 0;
+    int ret;
 
     assert(vfu_ctx != NULL);
     assert(msg != NULL);
@@ -457,12 +458,15 @@ handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     }
 
     if (caps_size > 0) {
-        out_info->flags |= VFIO_REGION_INFO_FLAG_CAPS;
         /* Only actually provide the caps if they fit. */
         if (in_info->argsz >= out_info->argsz) {
-            dev_get_caps(vfu_ctx, vfu_reg,
-                         in_info->index == VFU_PCI_DEV_MIGR_REGION_IDX,
-                         out_info, &msg->out_fds, &msg->nr_out_fds);
+            out_info->flags |= VFIO_REGION_INFO_FLAG_CAPS;
+            ret = dev_get_caps(vfu_ctx, vfu_reg,
+                               in_info->index == VFU_PCI_DEV_MIGR_REGION_IDX,
+                               out_info, &msg->out_fds, &msg->nr_out_fds);
+            if (ret < 0) {
+                return ret;
+            }
         }
     }
 

--- a/test/py/test_device_get_region_info.py
+++ b/test/py/test_device_get_region_info.py
@@ -136,8 +136,7 @@ def test_device_get_region_info_small_argsz_caps():
     assert info.argsz == 80
     assert info.flags == (VFIO_REGION_INFO_FLAG_READ |
                           VFIO_REGION_INFO_FLAG_WRITE |
-                          VFIO_REGION_INFO_FLAG_MMAP |
-                          VFIO_REGION_INFO_FLAG_CAPS)
+                          VFIO_REGION_INFO_FLAG_MMAP)
     assert info.index == VFU_PCI_DEV_BAR2_REGION_IDX
     assert info.cap_offset == 0
     assert info.size == 0x8000

--- a/test/py/test_device_get_region_info.py
+++ b/test/py/test_device_get_region_info.py
@@ -134,6 +134,11 @@ def test_device_get_region_info_small_argsz_caps():
     info, _ = vfio_region_info.pop_from_buffer(result)
 
     assert info.argsz == 80
+
+    '''
+    There are capabilites but we do not expect VFIO_REGION_INFO_FLAG_CAPS
+    to be set because they do not fit in reply as argsz is small
+    '''
     assert info.flags == (VFIO_REGION_INFO_FLAG_READ |
                           VFIO_REGION_INFO_FLAG_WRITE |
                           VFIO_REGION_INFO_FLAG_MMAP)


### PR DESCRIPTION
Set VFIO_REGION_INFO_FLAG_CAPS flag only if caps are part of the reply.

Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>