### PR TITLE
Use fedora35 for pre-push test

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -107,7 +107,7 @@ branches:
           - centos-7
           - ubuntu-18
           - ubuntu-20
-          - fedora-34
+          - fedora-35
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -37,7 +37,7 @@ jobs:
           yum -y install clang cmake json-c-devel libcmocka-devel \
               openssl-devel valgrind python36-pytest which
           make pre-push VERBOSE=1
-  fedora-34:
+  fedora-35:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     container: fedora
@@ -45,7 +45,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: pre-push
         run: |
-          dnf -y install --releasever=34 \
+          dnf -y install --releasever=35 \
               gcc make clang cmake json-c-devel libcmocka-devel openssl-devel \
               pciutils diffutils valgrind python3-pytest python3-flake8 which
           make pre-push VERBOSE=1


### PR DESCRIPTION
Recent pre-push runs on fedora34 are failing with setup issues,
where it complains abour GLIBC_2.34 not found.
Now instead we can start using fedora35

Signed-off-by: Swapnil Ingle <swapnil.ingle@nutanix.com>