### PR TITLE
refactor process_request()

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1167,8 +1167,8 @@ handle_request(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     }
 
     if (ret < 0) {
-        vfu_log(vfu_ctx, LOG_ERR, "msg%#hx: cmd %d failed: %m", msg->hdr.msg_id,
-                msg->hdr.cmd);
+        vfu_log(vfu_ctx, LOG_ERR, "msg%#hx: cmd %d failed: %m",
+                msg->hdr.msg_id, msg->hdr.cmd);
     }
 
     return do_reply(vfu_ctx, msg, ret == 0 ? 0 : errno);

--- a/lib/private.h
+++ b/lib/private.h
@@ -228,9 +228,6 @@ int
 consume_fd(int *fds, size_t nr_fds, size_t index);
 
 int
-exec_command(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
-
-int
 handle_dma_map(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg,
                struct vfio_user_dma_map *dma_map);
 


### PR DESCRIPTION
Instead of process_request() having a dual role, split into get_request() and
handle_request().

Signed-off-by: John Levon <john.levon@nutanix.com>