### PR TITLE
test/py: don't stop logging twice

### DIFF
--- a/test/py/test_dirty_pages.py
+++ b/test/py/test_dirty_pages.py
@@ -332,11 +332,6 @@ def stop_logging():
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload)
 
-    payload = vfio_user_dirty_pages(argsz=len(vfio_user_dirty_pages()),
-                                    flags=VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP)
-
-    msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload)
-
 
 def test_dirty_pages_stop():
     stop_logging()


### PR DESCRIPTION
We were accidentally calling VFIO_USER_DIRTY_PAGES twice.

Signed-off-by: John Levon <john.levon@nutanix.com>
