### PR TITLE
test/py: simplify errno handling

### DIFF
--- a/test/py/test_device_get_info.py
+++ b/test/py/test_device_get_info.py
@@ -54,7 +54,7 @@ def test_device_get_info():
     payload = struct.pack("II", 0, 0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     # bad argsz
 
@@ -62,7 +62,7 @@ def test_device_get_info():
                                     num_regions=0, num_irqs=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     # valid with larger argsz
 

--- a/test/py/test_device_get_irq_info.py
+++ b/test/py/test_device_get_irq_info.py
@@ -62,21 +62,21 @@ def test_device_get_irq_info_bad_in():
     payload = struct.pack("II", 0, 0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_IRQ_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     # bad argsz
     payload = vfio_irq_info(argsz=8, flags=0, index=VFU_DEV_REQ_IRQ,
                             count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_IRQ_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     # bad index
     payload = vfio_irq_info(argsz=argsz, flags=0, index=VFU_DEV_NUM_IRQS,
                             count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_IRQ_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_irq_info():

--- a/test/py/test_device_get_region_info.py
+++ b/test/py/test_device_get_region_info.py
@@ -97,7 +97,7 @@ def test_device_get_region_info_short_write():
     payload = struct.pack("II", 0, 0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_info_bad_argsz():
@@ -107,7 +107,7 @@ def test_device_get_region_info_bad_argsz():
                                size=0, offset=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_info_bad_index():
@@ -117,7 +117,7 @@ def test_device_get_region_info_bad_index():
                                size=0, offset=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_INFO, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 # python tests use max client fds of 8, but this region has 9 mmap areas.
@@ -128,7 +128,7 @@ def test_device_get_region_info_caps_too_few_fds():
     payload = bytes(payload) + b'\0' * (192 - 32)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_INFO, payload,
-        expect_reply_errno=errno.ENOSPC)
+        expect=errno.ENOSPC)
 
 
 def test_device_get_region_info_larger_argsz():

--- a/test/py/test_device_get_region_io_fds.py
+++ b/test/py/test_device_get_region_io_fds.py
@@ -88,7 +88,7 @@ def test_device_get_region_io_fds_bad_flags():
                 index=VFU_PCI_DEV_BAR2_REGION_IDX, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_bad_count():
@@ -99,7 +99,7 @@ def test_device_get_region_io_fds_bad_count():
                 index=VFU_PCI_DEV_BAR2_REGION_IDX, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_buffer_too_small():
@@ -109,7 +109,7 @@ def test_device_get_region_io_fds_buffer_too_small():
             index=VFU_PCI_DEV_BAR2_REGION_IDX, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_buffer_too_large():
@@ -120,7 +120,7 @@ def test_device_get_region_io_fds_buffer_too_large():
                                             count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_no_fds():
@@ -129,7 +129,7 @@ def test_device_get_region_io_fds_no_fds():
                                 index=VFU_PCI_DEV_BAR1_REGION_IDX, count=0)
 
     ret = msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-              expect_reply_errno=0)
+              expect=0)
 
     reply, ret = vfio_user_region_io_fds_reply.pop_from_buffer(ret)
 
@@ -145,7 +145,7 @@ def test_device_get_region_io_fds_no_regions_setup():
                                 index=VFU_PCI_DEV_BAR3_REGION_IDX, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_region_no_mmap():
@@ -154,7 +154,7 @@ def test_device_get_region_io_fds_region_no_mmap():
                                 index=VFU_PCI_DEV_BAR5_REGION_IDX, count=0)
 
     ret = msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-              expect_reply_errno=0)
+              expect=0)
 
     reply, ret = vfio_user_region_io_fds_reply.pop_from_buffer(ret)
 
@@ -170,7 +170,7 @@ def test_device_get_region_io_fds_region_out_of_range():
                                               index=512, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_get_region_io_fds_fds_read_write():

--- a/test/py/test_device_set_irqs.py
+++ b/test/py/test_device_set_irqs.py
@@ -70,7 +70,7 @@ def test_device_set_irqs_short_write():
     payload = struct.pack("II", 0, 0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_argsz():
@@ -79,7 +79,7 @@ def test_device_set_irqs_bad_argsz():
                            start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_index():
@@ -88,7 +88,7 @@ def test_device_set_irqs_bad_index():
                            start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_flags_MASK_and_UNMASK():
@@ -97,7 +97,7 @@ def test_device_set_irqs_bad_flags_MASK_and_UNMASK():
                            start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_flags_DATA_NONE_and_DATA_BOOL():
@@ -106,7 +106,7 @@ def test_device_set_irqs_bad_flags_DATA_NONE_and_DATA_BOOL():
                            index=VFU_DEV_MSIX_IRQ, start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_start_count_range():
@@ -115,7 +115,7 @@ def test_device_set_irqs_bad_start_count_range():
                            start=2047, count=2)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_start_count_range2():
@@ -124,7 +124,7 @@ def test_device_set_irqs_bad_start_count_range2():
                            start=2049, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_action_for_err_irq():
@@ -133,7 +133,7 @@ def test_device_set_irqs_bad_action_for_err_irq():
                            start=0, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_action_for_req_irq():
@@ -142,7 +142,7 @@ def test_device_set_irqs_bad_action_for_req_irq():
                            start=0, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_start_for_count_0():
@@ -151,7 +151,7 @@ def test_device_set_irqs_bad_start_for_count_0():
                            start=1, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_action_for_count_0():
@@ -160,7 +160,7 @@ def test_device_set_irqs_bad_action_for_count_0():
                            start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_action_and_data_type_for_count_0():
@@ -169,7 +169,7 @@ def test_device_set_irqs_bad_action_and_data_type_for_count_0():
                            start=0, count=0)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_bad_fds_for_DATA_BOOL():
@@ -182,7 +182,7 @@ def test_device_set_irqs_bad_fds_for_DATA_BOOL():
     fd = eventfd()
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL, fds=[fd])
+        expect=errno.EINVAL, fds=[fd])
 
     os.close(fd)
 
@@ -195,7 +195,7 @@ def test_device_set_irqs_bad_fds_for_DATA_NONE():
     fd = eventfd()
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL, fds=[fd])
+        expect=errno.EINVAL, fds=[fd])
 
     os.close(fd)
 
@@ -208,7 +208,7 @@ def test_device_set_irqs_bad_fds_for_count_2():
     fd = eventfd()
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL, fds=[fd])
+        expect=errno.EINVAL, fds=[fd])
 
     os.close(fd)
 
@@ -244,7 +244,7 @@ def test_device_set_irqs_trigger_bool_too_small():
     payload = bytes(payload) + struct.pack("?", False)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_trigger_bool_too_large():
@@ -254,7 +254,7 @@ def test_device_set_irqs_trigger_bool_too_large():
     payload = bytes(payload) + struct.pack("???", False, False, False)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_device_set_irqs_enable_update():

--- a/test/py/test_dirty_pages.py
+++ b/test/py/test_dirty_pages.py
@@ -92,7 +92,7 @@ def test_dirty_pages_short_write():
     payload = struct.pack("I", 8)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_bad_argsz():
@@ -100,7 +100,7 @@ def test_dirty_pages_bad_argsz():
         flags=VFIO_IOMMU_DIRTY_PAGES_FLAG_START)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_start_no_migration():
@@ -108,7 +108,7 @@ def test_dirty_pages_start_no_migration():
         flags=VFIO_IOMMU_DIRTY_PAGES_FLAG_START)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.ENOTSUP)
+        expect=errno.ENOTSUP)
 
 
 def test_dirty_pages_start_bad_flags():
@@ -123,14 +123,14 @@ def test_dirty_pages_start_bad_flags():
                VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP))
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     payload = vfio_user_dirty_pages(argsz=len(vfio_user_dirty_pages()),
         flags=(VFIO_IOMMU_DIRTY_PAGES_FLAG_START |
                VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP))
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def start_logging():
@@ -151,7 +151,7 @@ def test_dirty_pages_get_short_read():
         flags=VFIO_IOMMU_DIRTY_PAGES_FLAG_GET_BITMAP)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 #
@@ -167,7 +167,7 @@ def test_dirty_pages_get_sub_range():
     payload = bytes(dirty_pages) + bytes(br)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.ENOTSUP)
+        expect=errno.ENOTSUP)
 
 
 def test_dirty_pages_get_bad_page_size():
@@ -180,7 +180,7 @@ def test_dirty_pages_get_bad_page_size():
     payload = bytes(dirty_pages) + bytes(br)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_get_bad_bitmap_size():
@@ -193,7 +193,7 @@ def test_dirty_pages_get_bad_bitmap_size():
     payload = bytes(dirty_pages) + bytes(br)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_get_bad_argsz():
@@ -206,7 +206,7 @@ def test_dirty_pages_get_bad_argsz():
     payload = bytes(dirty_pages) + bytes(br)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_get_short_reply():
@@ -240,7 +240,7 @@ def test_get_dirty_page_bitmap_unmapped():
     payload = bytes(dirty_pages) + bytes(br)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dirty_pages_get_unmodified():

--- a/test/py/test_dma_map.py
+++ b/test/py/test_dma_map.py
@@ -62,7 +62,7 @@ def test_dma_region_too_big():
                VFIO_USER_F_DMA_REGION_WRITE),
         offset=0, addr=0x10000, size=MAX_DMA_SIZE + 4096)
 
-    msg(ctx, sock, VFIO_USER_DMA_MAP, payload, expect_reply_errno=errno.ENOSPC)
+    msg(ctx, sock, VFIO_USER_DMA_MAP, payload, expect=errno.ENOSPC)
 
 
 def test_dma_region_too_many():
@@ -79,7 +79,7 @@ def test_dma_region_too_many():
         else:
             expect = 0
 
-        msg(ctx, sock, VFIO_USER_DMA_MAP, payload, expect_reply_errno=expect)
+        msg(ctx, sock, VFIO_USER_DMA_MAP, payload, expect=expect)
 
 
 @patch('libvfio_user.quiesce_cb', side_effect=fail_with_errno(errno.EBUSY))
@@ -98,7 +98,7 @@ def test_dma_map_busy(mock_dma_register, mock_quiesce):
         offset=0, addr=0x10000, size=0x1000)
 
     msg(ctx, sock, VFIO_USER_DMA_MAP, payload, rsp=False,
-        expect_run_ctx_errno=errno.EBUSY)
+        busy=True)
 
     assert mock_dma_register.call_count == 0
 
@@ -195,7 +195,7 @@ def test_dma_map_busy_reply_fail(mock_dma_register, mock_quiesce, mock_reset):
         offset=0, addr=0x10000, size=0x1000)
 
     msg(ctx, sock, VFIO_USER_DMA_MAP, payload, rsp=False,
-        expect_run_ctx_errno=errno.EBUSY)
+        busy=True)
 
     mock_quiesce.assert_called_once_with(ctx)
 

--- a/test/py/test_dma_unmap.py
+++ b/test/py/test_dma_unmap.py
@@ -67,14 +67,14 @@ def setup_dma_regions(dma_regions=[(0x0, 0x1000)]):
 def test_dma_unmap_short_write():
     payload = struct.pack("II", 0, 0)
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_bad_argsz():
 
     payload = vfio_user_dma_unmap(argsz=8, flags=0, addr=0x1000, size=4096)
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_bad_argsz2():
@@ -82,7 +82,7 @@ def test_dma_unmap_bad_argsz2():
     payload = vfio_user_dma_unmap(argsz=SERVER_MAX_DATA_XFER_SIZE + 8, flags=0,
                                   addr=0x1000, size=4096)
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_dirty_bad_argsz():
@@ -94,7 +94,7 @@ def test_dma_unmap_dirty_bad_argsz():
     payload = bytes(unmap) + bytes(bitmap)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_dirty_not_tracking():
@@ -107,7 +107,7 @@ def test_dma_unmap_dirty_not_tracking():
     payload = bytes(unmap) + bytes(bitmap) + bytes(8)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_dirty_not_mapped():
@@ -126,7 +126,7 @@ def test_dma_unmap_dirty_not_mapped():
     payload = bytes(unmap) + bytes(bitmap) + bytes(8)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_invalid_flags():
@@ -135,7 +135,7 @@ def test_dma_unmap_invalid_flags():
     payload = vfio_user_dma_unmap(argsz=len(vfio_user_dma_unmap()),
                                   flags=0x4, addr=0x1000, size=4096)
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap():
@@ -153,7 +153,7 @@ def test_dma_unmap_invalid_addr():
                                   addr=0x10000, size=4096)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.ENOENT)
+        expect=errno.ENOENT)
 
 
 @patch('libvfio_user.quiesce_cb')
@@ -164,7 +164,7 @@ def test_dma_unmap_async(mock_quiesce):
     payload = vfio_user_dma_unmap(argsz=len(vfio_user_dma_unmap()),
                                   flags=0, addr=0x0, size=0x1000)
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload, rsp=False,
-        expect_run_ctx_errno=errno.EBUSY)
+        busy=True)
 
     ret = vfu_device_quiesced(ctx, 0)
     assert ret == 0
@@ -189,7 +189,7 @@ def test_dma_unmap_all_invalid_addr():
         flags=VFIO_DMA_UNMAP_FLAG_ALL, addr=0x10000, size=4096)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 
 def test_dma_unmap_all_invalid_flags():
@@ -199,7 +199,7 @@ def test_dma_unmap_all_invalid_flags():
                addr=0, size=0)
 
     msg(ctx, sock, VFIO_USER_DMA_UNMAP, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
 # FIXME need to add unit tests that test errors in get_request_header,
 # do_reply, vfu_dma_transfer

--- a/test/py/test_migration.py
+++ b/test/py/test_migration.py
@@ -129,7 +129,7 @@ def test_migration_trans_async(mock_trans, mock_quiesce):
     data = VFIO_DEVICE_STATE_SAVING.to_bytes(c.sizeof(c.c_int), 'little')
     write_region(ctx, sock, VFU_PCI_DEV_MIGR_REGION_IDX, offset=0,
                  count=len(data), data=data, rsp=False,
-                 expect_run_ctx_errno=errno.EBUSY)
+                 busy=True)
 
     ret = vfu_device_quiesced(ctx, 0)
     assert ret == 0
@@ -154,7 +154,7 @@ def test_migration_trans_async_err(mock_trans, mock_quiesce):
     data = VFIO_DEVICE_STATE_RUNNING.to_bytes(c.sizeof(c.c_int), 'little')
     write_region(ctx, sock, VFU_PCI_DEV_MIGR_REGION_IDX, offset=0,
                  count=len(data), data=data, rsp=False,
-                 expect_run_ctx_errno=errno.EBUSY)
+                 busy=True)
 
     ret = vfu_device_quiesced(ctx, 0)
     assert ret == 0

--- a/test/py/test_negotiate.py
+++ b/test/py/test_negotiate.py
@@ -186,7 +186,7 @@ def test_valid_negotiate_empty_json():
     client_version_json(json=b'{}')
 
     # notice client closed connection
-    vfu_run_ctx(ctx)
+    vfu_run_ctx(ctx, expect=errno.ENOTCONN)
 
 
 def test_valid_negotiate_json():
@@ -196,7 +196,7 @@ def test_valid_negotiate_json():
          "utf-8"))
 
     # notice client closed connection
-    vfu_run_ctx(ctx)
+    vfu_run_ctx(ctx, expect=errno.ENOTCONN)
 
 
 def test_destroying():

--- a/test/py/test_request_errors.py
+++ b/test/py/test_request_errors.py
@@ -206,7 +206,7 @@ def test_reply_fail_quiesce_busy(mock_get_pending_bytes, mock_quiesce,
     read_region(ctx, sock, VFU_PCI_DEV_MIGR_REGION_IDX,
                 vfio_user_migration_info.pending_bytes.offset,
                 vfio_user_migration_info.pending_bytes.size, rsp=False,
-                expect_run_ctx_errno=errno.EBUSY)
+                busy=True)
 
     # vfu_run_ctx will try to reset the context and to do that it needs to
     # quiesce the device first

--- a/test/py/test_setup_region.py
+++ b/test/py/test_setup_region.py
@@ -234,7 +234,7 @@ def test_region_offset_too_short():
     payload = struct.pack("Q", 0)
 
     msg(ctx, sock, VFIO_USER_REGION_WRITE, payload,
-        expect_reply_errno=errno.EINVAL)
+        expect=errno.EINVAL)
 
     disconnect_client(ctx, sock)
 

--- a/test/py/test_vfu_realize_ctx.py
+++ b/test/py/test_vfu_realize_ctx.py
@@ -27,7 +27,6 @@
 #  DAMAGE.
 #
 
-import ctypes as c
 import errno
 from libvfio_user import *
 
@@ -49,9 +48,7 @@ def test_vfu_unrealized_ctx():
     ctx = vfu_create_ctx()
     assert ctx is not None
 
-    ret = vfu_run_ctx(ctx)
-    assert ret == -1
-    assert c.get_errno() == errno.EINVAL
+    vfu_run_ctx(ctx, errno.EINVAL)
 
     vfu_destroy_ctx(ctx)
 


### PR DESCRIPTION
We explicitly identify the quiesce EBUSY case for msg(), letting us simplify the
handling of expected errno.

Signed-off-by: John Levon <john.levon@nutanix.com>
