### PR TITLE
retire ubuntu-18 CI

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -105,7 +105,6 @@ branches:
         # Required. The list of status checks to require in order to merge into this branch
         contexts:
           - centos-7
-          - ubuntu-18
           - ubuntu-20
           - fedora-35
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,18 +12,6 @@ jobs:
           sudo apt-get -y install libjson-c-dev libcmocka-dev clang valgrind \
                                   python3-pytest debianutils flake8
           make pre-push VERBOSE=1
-  ubuntu-18:
-    timeout-minutes: 10
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: pre-push
-        run: |
-          # NB: no working flake8
-          sudo apt update
-          sudo apt-get -y install libjson-c-dev libcmocka-dev clang valgrind \
-                                  python3-pytest debianutils
-          make pre-push VERBOSE=1
   centos-7:
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
This OS version's valgrind lacks --exit-on-first-error, so let's stop
trying to build in it. We still have centos 7 as "old Linux".

Signed-off-by: John Levon <john.levon@nutanix.com>
