### PR TITLE
add compile_commands.json generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,9 @@ include(GNUInstallDirs)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(JSON REQUIRED json-c)
 
+# for LSP
+set(CMAKE_EXPORT_COMPILE_COMMANDS TRUE)
+
 # for the benefit of the gcov rules
 set(CMAKE_C_OUTPUT_EXTENSION_REPLACE 1)
 


### PR DESCRIPTION
For use by LSP, generate a compile_commands.json file.

Signed-off-by: John Levon <john.levon@nutanix.com>
