### PR TITLE
fix a small coverity complaint

### DIFF
--- a/lib/tran_pipe.c
+++ b/lib/tran_pipe.c
@@ -243,7 +243,6 @@ static int
 tran_pipe_init(vfu_ctx_t *vfu_ctx)
 {
     tran_pipe_t *tp = NULL;
-    int ret = 0;
 
     assert(vfu_ctx != NULL);
 
@@ -255,11 +254,6 @@ tran_pipe_init(vfu_ctx_t *vfu_ctx)
 
     tp->in_fd = -1;
     tp->out_fd = -1;
-
-    if (ret != 0) {
-        free(tp);
-        return ERROR_INT(ret);
-    }
 
     vfu_ctx->tran_data = tp;
     return 0;


### PR DESCRIPTION
The complaint was:

259         if (ret != 0) {
>>>     CID 392380:  Possible Control flow issues  (DEADCODE)
>>>     Execution cannot reach this statement: "free(tp);".
260             free(tp);
261             return ERROR_INT(ret);
262         }

Signed-off-by: John Levon <john.levon@nutanix.com>
