### PR TITLE
lib: export dma_sg_size symbol in library

### DIFF
--- a/lib/dma.c
+++ b/lib/dma.c
@@ -44,7 +44,7 @@
 #include "dma.h"
 #include "private.h"
 
-size_t
+EXPORT size_t
 dma_sg_size(void)
 {
     return sizeof(dma_sg_t);

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -613,6 +613,7 @@ lib.vfu_setup_device_dma.argtypes = (c.c_void_p, vfu_dma_register_cb_t,
                                      vfu_dma_unregister_cb_t)
 lib.vfu_setup_device_migration_callbacks.argtypes = (c.c_void_p,
     c.POINTER(vfu_migration_callbacks_t), c.c_uint64)
+lib.dma_sg_size.restype = (c.c_size_t)
 lib.vfu_addr_to_sg.argtypes = (c.c_void_p, c.c_void_p, c.c_size_t,
                                c.POINTER(dma_sg_t), c.c_int, c.c_int)
 lib.vfu_map_sg.argtypes = (c.c_void_p, c.POINTER(dma_sg_t), c.POINTER(iovec_t),
@@ -1143,6 +1144,10 @@ def vfu_setup_device_migration_callbacks(ctx, cbs=None, offset=0x4000):
         cbs.data_written = __migr_data_written_cb
 
     return lib.vfu_setup_device_migration_callbacks(ctx, cbs, offset)
+
+
+def dma_sg_size():
+    return lib.dma_sg_size()
 
 
 def vfu_addr_to_sg(ctx, dma_addr, length, max_sg=1,

--- a/test/py/test_map_unmap_sg.py
+++ b/test/py/test_map_unmap_sg.py
@@ -35,6 +35,11 @@ import tempfile
 ctx = None
 
 
+def test_dma_sg_size():
+    size = dma_sg_size()
+    assert size == len(dma_sg_t())
+
+
 def test_map_sg_with_invalid_region():
     global ctx
 


### PR DESCRIPTION
The dma_sg_size() method is listed in libvfio-user.h but the symbol
is marked private in the ELF library.
