### PR TITLE
add an ubuntu-latest PR run

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -106,6 +106,7 @@ branches:
         contexts:
           - centos-7
           - ubuntu-20
+          - ubuntu-22
           - fedora-35
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -13,6 +13,18 @@ jobs:
                                   python3-pytest debianutils flake8 meson \
                                   ninja-build
           ./.github/workflows/pull_request.sh
+  ubuntu-22:
+    timeout-minutes: 10
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: pre-push
+        run: |
+          sudo apt-get update
+          sudo apt-get -y install libjson-c-dev libcmocka-dev clang valgrind \
+                                  python3-pytest debianutils flake8 meson \
+                                  ninja-build
+          ./.github/workflows/pull_request.sh
   centos-7:
     timeout-minutes: 10
     runs-on: ubuntu-latest

--- a/meson.build
+++ b/meson.build
@@ -8,6 +8,8 @@ project(
         'buildtype=debugoptimized',
         'c_std=gnu99',
         'warning_level=2',
+        # clang with dwarf-5 can break valgrind
+        'c_args=-gdwarf-4',
     ],
 )
 


### PR DESCRIPTION
Without this, we didn't detect the openssl-3.0 build breakage.

Signed-off-by: John Levon <john.levon@nutanix.com>
