### PR TITLE
build PR runs in release mode

### DIFF
--- a/.github/workflows/pull_request.sh
+++ b/.github/workflows/pull_request.sh
@@ -18,22 +18,22 @@ CC=clang meson build/clang-debug -Dtran-pipe=true
 ninja -C $BUILD/clang-debug -v
 meson test -C $BUILD/clang-debug --no-suite style --print-errorlogs
 
-# plain build with clang
-CC=clang meson build/clang-plain -Dtran-pipe=true -Dbuildtype=plain
-ninja -C $BUILD/clang-plain -v
-meson test -C $BUILD/clang-plain --no-suite style --print-errorlogs
+# release build with clang
+CC=clang meson build/clang-release -Dtran-pipe=true -Dbuildtype=release
+ninja -C $BUILD/clang-release -v
+meson test -C $BUILD/clang-release --no-suite style --print-errorlogs
 
 # debug build with gcc
 CC=gcc meson build/gcc-debug -Dtran-pipe=true
 ninja -C $BUILD/gcc-debug -v
 meson test -C $BUILD/gcc-debug --no-suite style --print-errorlogs
 
-# plain build with gcc
-CC=gcc meson build/gcc-plain -Dtran-pipe=true -Dbuildtype=plain
-ninja -C $BUILD/gcc-plain -v
-meson test -C $BUILD/gcc-plain --no-suite style --print-errorlogs
+meson test -C $BUILD/gcc-debug --suite unit --setup valgrind --print-errorlogs
+meson test -C $BUILD/gcc-debug --suite pyunit --setup pyvalgrind --print-errorlogs
 
-meson test -C $BUILD/gcc-plain --suite unit --setup valgrind --print-errorlogs
-meson test -C $BUILD/gcc-plain --suite pyunit --setup pyvalgrind --print-errorlogs
+DESTDIR=tmp.install meson install -C $BUILD/gcc-debug
 
-DESTDIR=tmp.install meson install -C $BUILD/gcc-plain
+# release build with gcc
+CC=gcc meson build/gcc-release -Dtran-pipe=true -Dbuildtype=release
+ninja -C $BUILD/gcc-release -v
+meson test -C $BUILD/gcc-release --no-suite style --print-errorlogs

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
     license: 'BSD-3-Clause',
     meson_version: '>= 0.53.0',
     default_options: [
-        'buildtype=debugoptimized',
+        'buildtype=debug',
         'c_std=gnu99',
         'warning_level=2',
         # clang with dwarf-5 can break valgrind


### PR DESCRIPTION
Instead of "plain", which doesn't specify any optimization, use
"release", which both turns off -DDEBUG and enables -O3.

Signed-off-by: John Levon <john.levon@nutanix.com>