### PR TITLE
re-work SG dirty tracking

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -803,8 +803,21 @@ vfu_map_sg(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, struct iovec *iov, int cnt,
            int flags);
 
 /**
+ * Mark scatter/gather entries (previously mapped by vfu_map_sg()) as dirty
+ * (written to). This is only necessary if vfu_unmap_sg() is not called.
+ *
+ * @vfu_ctx: the libvfio-user context
+ * @sg: array of scatter/gather entries to mark as dirty
+ * @cnt: number of scatter/gather entries to mark as dirty
+ */
+void
+vfu_mark_sg_dirty(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, int cnt);
+
+/**
  * Unmaps scatter/gather entries (previously mapped by vfu_map_sg()) from
  * the process's virtual memory.
+ *
+ * This will automatically mark the sg as dirty if needed.
  *
  * @vfu_ctx: the libvfio-user context
  * @sg: array of scatter/gather entries to unmap

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -2038,7 +2038,7 @@ vfu_map_sg(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, struct iovec *iov, int cnt,
 }
 
 EXPORT void
-vfu_unmap_sg(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, struct iovec *iov, int cnt)
+vfu_mark_sg_dirty(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, int cnt)
 {
     if (unlikely(vfu_ctx->dma_unregister == NULL)) {
         return;
@@ -2046,7 +2046,20 @@ vfu_unmap_sg(vfu_ctx_t *vfu_ctx, dma_sg_t *sg, struct iovec *iov, int cnt)
 
     quiesce_check_allowed(vfu_ctx);
 
-    return dma_unmap_sg(vfu_ctx->dma, sg, iov, cnt);
+    return dma_mark_sg_dirty(vfu_ctx->dma, sg, cnt);
+}
+
+EXPORT void
+vfu_unmap_sg(vfu_ctx_t *vfu_ctx, dma_sg_t *sg,
+             struct iovec *iov UNUSED, int cnt)
+{
+    if (unlikely(vfu_ctx->dma_unregister == NULL)) {
+        return;
+    }
+
+    quiesce_check_allowed(vfu_ctx);
+
+    return dma_unmap_sg(vfu_ctx->dma, sg, cnt);
 }
 
 static int

--- a/test/py/test_dirty_pages.py
+++ b/test/py/test_dirty_pages.py
@@ -318,6 +318,7 @@ def test_dirty_pages_get_modified():
     ret = vfu_map_sg(ctx, sg1, iovec1)
     assert ret == 0
 
+    # read only
     ret, sg2 = vfu_addr_to_sg(ctx, dma_addr=0x11000, length=0x1000,
                               prot=mmap.PROT_READ)
     assert ret == 1
@@ -325,52 +326,47 @@ def test_dirty_pages_get_modified():
     ret = vfu_map_sg(ctx, sg2, iovec2)
     assert ret == 0
 
-    global sg3, iovec3
-    ret, sg3 = vfu_addr_to_sg(ctx, dma_addr=0x14000, length=0x4000)
+    ret, sg3 = vfu_addr_to_sg(ctx, dma_addr=0x12000, length=0x1000)
     assert ret == 1
     iovec3 = iovec_t()
     ret = vfu_map_sg(ctx, sg3, iovec3)
     assert ret == 0
 
-    bitmap = get_dirty_page_bitmap()
-    assert bitmap == 0b11110001
+    ret, sg4 = vfu_addr_to_sg(ctx, dma_addr=0x14000, length=0x4000)
+    assert ret == 1
+    iovec4 = iovec_t()
+    ret = vfu_map_sg(ctx, sg4, iovec4)
+    assert ret == 0
 
-    # unmap segment, dirty bitmap should be the same
+    # not unmapped yet, dirty bitmap should be zero, but dirty maps will have
+    # been marked dirty still
+    bitmap = get_dirty_page_bitmap()
+    assert bitmap == 0b00000000
+
+    # unmap segments, dirty bitmap should be updated
     vfu_unmap_sg(ctx, sg1, iovec1)
+    vfu_unmap_sg(ctx, sg4, iovec4)
     bitmap = get_dirty_page_bitmap()
-    assert bitmap == 0b11110001
+    assert bitmap == 0b11110101
 
-    # check again, previously unmapped segment should be clean
+    # after another two unmaps, should just be one dirty page
+    vfu_unmap_sg(ctx, sg2, iovec2)
+    vfu_unmap_sg(ctx, sg3, iovec3)
     bitmap = get_dirty_page_bitmap()
-    assert bitmap == 0b11110000
+    assert bitmap == 0b00000100
+
+    # and should now be clear
+    bitmap = get_dirty_page_bitmap()
+    assert bitmap == 0b00000000
 
 
-def stop_logging():
+def test_dirty_pages_stop():
+    # FIXME we have a memory leak as we don't free dirty bitmaps when
+    # destroying the context.
     payload = vfio_user_dirty_pages(argsz=len(vfio_user_dirty_pages()),
                                     flags=VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP)
 
     msg(ctx, sock, VFIO_USER_DIRTY_PAGES, payload)
-
-
-def test_dirty_pages_stop():
-    stop_logging()
-
-    # one segment is still mapped, starting logging again and bitmap should be
-    # dirty
-    start_logging()
-    assert get_dirty_page_bitmap() == 0b11110000
-
-    # unmap segment, bitmap should still be dirty
-    vfu_unmap_sg(ctx, sg3, iovec3)
-    assert get_dirty_page_bitmap() == 0b11110000
-
-    # bitmap should be clear after it was unmapped before previous request for
-    # dirty pages
-    assert get_dirty_page_bitmap() == 0b00000000
-
-    # FIXME we have a memory leak as we don't free dirty bitmaps when
-    # destroying the context.
-    stop_logging()
 
 
 def test_dirty_pages_start_with_quiesce():
@@ -402,6 +398,7 @@ def test_dirty_pages_bitmap_with_quiesce():
     iovec1 = iovec_t()
     ret = vfu_map_sg(ctx, sg1, iovec1)
     assert ret == 0
+    vfu_unmap_sg(ctx, sg1, iovec1)
 
     send_dirty_page_bitmap(busy=True)
 


### PR DESCRIPTION
Move SG dirtying to vfu_unmap_sg(): as we don't want to track SGs
ourselves, doing this in vfu_map_sg() is no longer the right place.

Note that the lack of tracking implies that any SGs must be unmapped
before the final stop and copy phase. To avoid the need for this, add
vfu_mark_sg_dirty(): this allows a consumer to mark a region as dirty
explicitly without needing to unmap it. Currently it's the same as
vfu_unmap_sg(), but that's an implementation detail.

Note this still marks current maps after a get operation; that will
change subsequently.

Signed-off-by: John Levon <john.levon@<a href="nutanix.com">nutanix.com</a>>

---

**Stack**:
- #677
- #676
- #675
- #674
- #673
- #672 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*