### PR TITLE
remove maps list from DMA controller

### DIFF
--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -547,8 +547,6 @@ class dma_sg_t(Structure):
         ("length", c.c_uint64),
         ("offset", c.c_uint64),
         ("writeable", c.c_bool),
-        ("le_next", c.c_void_p),
-        ("le_prev", c.c_void_p),
     ]
 
     def __str__(self):

--- a/test/py/test_dirty_pages.py
+++ b/test/py/test_dirty_pages.py
@@ -347,7 +347,7 @@ def test_dirty_pages_get_modified():
     vfu_unmap_sg(ctx, sg1, iovec1)
     vfu_unmap_sg(ctx, sg4, iovec4)
     bitmap = get_dirty_page_bitmap()
-    assert bitmap == 0b11110101
+    assert bitmap == 0b11110001
 
     # after another two unmaps, should just be one dirty page
     vfu_unmap_sg(ctx, sg2, iovec2)


### PR DESCRIPTION
->maps existed so that if a consumer does vfu_map_sg() and then we are asked to
enable dirty page tracking, we won't mark those pages as dirty, and will hence
potentially lose data.

Now that we require quiesce and the use of either vfu_unmap_sg() or
vfu_sg_mark_dirty(), there's no need to have this list any more.

Signed-off-by: John Levon <john.levon@<a href="nutanix.com">nutanix.com</a>>

---

**Stack**:
- #677
- #676
- #675
- #674 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*