### PR TITLE
re-instate -Werror

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -49,6 +49,10 @@ common_cflags = [
     '-D_GNU_SOURCE',
 ]
 
+if opt_debug
+    common_cflags += '-Werror'
+endif
+
 if opt_debug_logs.enabled() or (not opt_debug_logs.disabled() and opt_debug)
     common_cflags += ['-DDEBUG']
 endif


### PR DESCRIPTION
This got lost in the translation to meson; add -Werror for debug builds.

Signed-off-by: John Levon <john.levon@nutanix.com>
