### PR TITLE
samples/client.c: fix implicit casting of const char pointers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -63,6 +63,7 @@ if get_option('warning_level') == '2'
     common_cflags += cc.get_supported_arguments([
         '-Wno-missing-field-initializers',
         '-Wmissing-declarations',
+        '-Wwrite-strings',
     ])
 endif
 

--- a/samples/client.c
+++ b/samples/client.c
@@ -54,7 +54,7 @@
 /* This is low, so we get testing of vfu_dma_read/write() chunking. */
 #define CLIENT_MAX_DATA_XFER_SIZE (1024)
 
-static char *irq_to_str[] = {
+static char const *irq_to_str[] = {
     [VFU_DEV_INTX_IRQ] = "INTx",
     [VFU_DEV_MSI_IRQ] = "MSI",
     [VFU_DEV_MSIX_IRQ] = "MSI-X",
@@ -947,7 +947,7 @@ migrate_to(char *old_sock_path, int *server_max_fds,
     if (ret > 0) { /* child (destination server) */
         char *_argv[] = {
             path_to_server,
-            "-v",
+            (char *)"-v",
             sock_path,
             NULL
         };


### PR DESCRIPTION
samples/client.c implicitly casts const char * to char * in a couple of
places - as such discards the const qualifier. QEMU complains about this
as it builds with -Werror=discarded-qualifiers

This patch declares irq_to_str as an array of const char pointers. It also
casts a "migrate_to() -> _argv" member explicitly

Also adds '-Wwrite-strings' build flag to catch similar issues in the
future

Signed-off-by: Jagannathan Raman <jag.raman@oracle.com>