### PR TITLE
fix fedora CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -41,7 +41,7 @@ jobs:
   fedora-35:
     timeout-minutes: 10
     runs-on: ubuntu-latest
-    container: fedora
+    container: fedora:35
     steps:
       - uses: actions/checkout@v2
       - name: pre-push


### PR DESCRIPTION
Presumably Fedora 36 came out, as our docker label moved, and we can no
longer install. Fix the docker label to fedora:35 to fix.

Signed-off-by: John Levon <john.levon@nutanix.com>

commit-id:ae8f8c5c
