### PR TITLE
meson: skip tests for subproject

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -70,5 +70,8 @@ endif
 subdir('include')
 subdir('lib')
 subdir('samples')
-subdir('test')
 subdir('docs')
+
+if not meson.is_subproject()
+    subdir('test')
+endif


### PR DESCRIPTION
when libvfio-user is building as subproject, the test environment of the
master project sometimes is not suitable to run libvfio-user tests.

For example, some of the containers used for QEMU don't have the lspci
command, as such test-lspci.sh fails. test-linkage.sh also fails because
it searches for header files in the master project's include directory.
As such, skipping libvfio-user tests from the master project test suite.

Signed-off-by: Jagannathan Raman <jag.raman@oracle.com>