### PR TITLE
tests: add checks to confirm test environment

### DIFF
--- a/test/meson.build
+++ b/test/meson.build
@@ -83,14 +83,14 @@ test(
     timeout: 90,
 )
 
-if opt_sanitizers == 'none'
+if opt_sanitizers == 'none' and meson.version().version_compare('>=0.56.0')
     test(
         'test-linkage.sh',
         find_program('test-linkage.sh'),
         suite: 'functional',
         args: [
-            meson.source_root(),
-            meson.build_root(),
+            meson.project_source_root(),
+            meson.project_build_root(),
             ' '.join(cc.cmd_array()),
         ]
     )

--- a/test/test-lspci.sh
+++ b/test/test-lspci.sh
@@ -7,6 +7,11 @@
 
 LSPCI=../samples/lspci
 
+if ! command -v lspci &> /dev/null
+then
+    exit 77
+fi
+
 test -n "$1" && LSPCI="$1"
 
 $LSPCI | lspci -vv -F /dev/stdin >lspci.out


### PR DESCRIPTION
test-lspci.sh: some test platforms don't include the lspci command, as
such skip this test if lspci is not found

test-linkage.sh: specify the source and build root paths of the subproject
instead of the root paths of the master project

Signed-off-by: Jagannathan Raman <jag.raman@oracle.com>