### PR TITLE
allow all LOG_* levels

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1748,8 +1748,7 @@ vfu_get_poll_fd(vfu_ctx_t *vfu_ctx)
 EXPORT int
 vfu_setup_log(vfu_ctx_t *vfu_ctx, vfu_log_fn_t *log, int log_level)
 {
-
-    if (log_level != LOG_ERR && log_level != LOG_INFO && log_level != LOG_DEBUG) {
+    if (log_level < LOG_EMERG || log_level > LOG_DEBUG) {
         return ERROR_INT(EINVAL);
     }
 


### PR DESCRIPTION
While libvfio-user doesn't use them all, at least SPDK was expecting to
be able to set LOG_NOTICE level, and silently failing. There's no reason
we can't support any valid syslog level.

Signed-off-by: John Levon <john.levon@nutanix.com>

commit-id:62dc1f6c
