### PR TITLE
test/py: fix the arguments for vfu_dev_irq_state_cb_t

### DIFF
--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -625,7 +625,7 @@ lib.vfu_create_ioeventfd.argtypes = (c.c_void_p, c.c_uint32, c.c_int,
 lib.vfu_device_quiesced.argtypes = (c.c_void_p, c.c_int)
 
 vfu_dev_irq_state_cb_t = c.CFUNCTYPE(None, c.c_void_p, c.c_uint32,
-                                     c.c_bool, use_errno=True)
+                                     c.c_uint32, c.c_bool, use_errno=True)
 lib.vfu_setup_irq_state_callback.argtypes = (c.c_void_p, c.c_int,
                                              vfu_dev_irq_state_cb_t)
 
@@ -1035,13 +1035,13 @@ def vfu_setup_device_nr_irqs(ctx, irqtype, count):
     return lib.vfu_setup_device_nr_irqs(ctx, irqtype, count)
 
 
-def irq_state(ctx, vector, mask):
+def irq_state(ctx, start, count, mask):
     pass
 
 
 @vfu_dev_irq_state_cb_t
-def __irq_state(ctx, vector, mask):
-    irq_state(ctx, vector, mask)
+def __irq_state(ctx, start, count, mask):
+    irq_state(ctx, start, count, mask)
 
 
 def vfu_setup_irq_state_callback(ctx, irqtype, cb=__irq_state):

--- a/test/py/test_device_set_irqs.py
+++ b/test/py/test_device_set_irqs.py
@@ -28,6 +28,7 @@
 #
 
 from unittest.mock import patch
+from unittest.mock import ANY
 
 from libvfio_user import *
 import errno
@@ -323,6 +324,8 @@ def test_irq_state(mock_irq_state):
                            start=0, count=1)
 
     msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload)
+
+    mock_irq_state.assert_called_with(ANY, 0, 1, True)
 
     assert mock_irq_state.call_count == 1
 


### PR DESCRIPTION
There is a typo in the arguments for vfu_dev_irq_state_cb_t - fix it in
this patch.

Signed-off-by: Jagannathan Raman <jag.raman@oracle.com>