### PR TITLE
disable client-server test by default

### DIFF
--- a/meson_options.txt
+++ b/meson_options.txt
@@ -6,3 +6,5 @@ option('debug-logs', type: 'feature', value: 'auto',
        description: 'enable extra debugging code (default for debug builds)')
 option('shadow-ioeventfd', type: 'boolean', value : false,
        description: 'enable shadow ioeventfd (experimental)')
+option('client-server-test', type: 'boolean', value : false,
+       description: 'enable client-server test (flaky)')

--- a/test/meson.build
+++ b/test/meson.build
@@ -69,19 +69,21 @@ test(
     args: [lspci],
 )
 
-csenv = []
-if opt_sanitizers != 'none'
-    csenv += ['WITH_ASAN=1']
-endif
+if get_option('client-server-test')
+    csenv = []
+    if opt_sanitizers != 'none'
+        csenv += ['WITH_ASAN=1']
+    endif
 
-test(
-    'test-client-server',
-    find_program('test-client-server.sh'),
-    env: csenv,
-    suite: 'functional',
-    args: [client, server],
-    timeout: 90,
-)
+    test(
+        'test-client-server',
+        find_program('test-client-server.sh'),
+        env: csenv,
+        suite: 'functional',
+        args: [client, server],
+        timeout: 90,
+    )
+endif
 
 if opt_sanitizers == 'none' and meson.version().version_compare('>=0.56.0')
     test(


### PR DESCRIPTION
This test is flaky: there is some kind of race that causes the test to
hang. Now we are run as part of qemu CI, we need to disable this by
default, until we can find time to fix the test.

Signed-off-by: John Levon <john.levon@nutanix.com>
