### PR TITLE
avoid vfu_log() in SGL hot path

### DIFF
--- a/.github/workflows/pull_request.sh
+++ b/.github/workflows/pull_request.sh
@@ -32,7 +32,7 @@ ninja -C $BUILD/clang-release -v
 meson test -C $BUILD/clang-release --no-suite style --print-errorlogs
 
 # debug build with gcc
-CC=gcc meson setup build/gcc-debug -Dtran-pipe=true
+CC=gcc meson setup build/gcc-debug -Dtran-pipe=true -Ddebug-sgl=true
 ninja -C $BUILD/gcc-debug -v
 meson test -C $BUILD/gcc-debug --no-suite style --print-errorlogs
 

--- a/lib/dma.h
+++ b/lib/dma.h
@@ -288,9 +288,13 @@ dma_sgl_get(dma_controller_t *dma, dma_sg_t *sgl, struct iovec *iov, size_t cnt)
             return ERROR_INT(EFAULT);
         }
 
+#ifdef DEBUG_SGL
         vfu_log(dma->vfu_ctx, LOG_DEBUG, "map %p-%p",
                 sg->dma_addr + sg->offset,
                 sg->dma_addr + sg->offset + sg->length);
+
+#endif
+
         iov->iov_base = region->info.vaddr + sg->offset;
         iov->iov_len = sg->length;
 
@@ -326,9 +330,12 @@ dma_sgl_mark_dirty(dma_controller_t *dma, dma_sg_t *sgl, size_t cnt)
             }
         }
 
+#ifdef DEBUG_SGL
         vfu_log(dma->vfu_ctx, LOG_DEBUG, "mark dirty %p-%p",
                 sg->dma_addr + sg->offset,
                 sg->dma_addr + sg->offset + sg->length);
+#endif
+
         sg++;
     } while (--cnt > 0);
 }
@@ -358,9 +365,12 @@ dma_sgl_put(dma_controller_t *dma, dma_sg_t *sgl, size_t cnt)
             }
         }
 
+#ifdef DEBUG_SGL
         vfu_log(dma->vfu_ctx, LOG_DEBUG, "unmap %p-%p",
                 sg->dma_addr + sg->offset,
                 sg->dma_addr + sg->offset + sg->length);
+#endif
+
         sg++;
     } while (--cnt > 0);
 }

--- a/meson.build
+++ b/meson.build
@@ -19,6 +19,7 @@ opt_debug_logs = get_option('debug-logs')
 opt_sanitizers = get_option('b_sanitize')
 opt_debug = get_option('debug')
 opt_shadow_ioeventfd = get_option('shadow-ioeventfd')
+opt_debug_sgl = get_option('debug-sgl')
 
 cc = meson.get_compiler('c')
 
@@ -60,6 +61,10 @@ endif
 
 if opt_shadow_ioeventfd
     common_cflags += ['-DSHADOW_IOEVENTFD']
+endif
+
+if opt_debug_sgl
+    common_cflags += ['-DDEBUG_SGL']
 endif
 
 if get_option('warning_level') == '2'

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -8,3 +8,5 @@ option('shadow-ioeventfd', type: 'boolean', value : false,
        description: 'enable shadow ioeventfd (experimental)')
 option('client-server-test', type: 'boolean', value : false,
        description: 'enable client-server test (flaky)')
+option('debug-sgl', type: 'boolean', value : false,
+       description: 'additional debugging for sgl maps')


### PR DESCRIPTION
Even though in non-debug, we don't actually log anything here, even
assembling the arguments to vfu_log() has a performance impact. Hide
them behind a DEBUG_SGL define - even in a DEBUG build, they are
particularly noisy and low-value.

Signed-off-by: John Levon <john.levon@nutanix.com>
