### PR TITLE
test: use `grep -E` instead of `egrep`

### DIFF
--- a/test/test-linkage.sh
+++ b/test/test-linkage.sh
@@ -41,7 +41,7 @@ tmpfile=$(mktemp /tmp/libvfio-user.test-linkage.XXXXXX.c)
 cat >$tmpfile <<EOF
 int main() {
 
-$(egrep '^[a-z_0-9]+\(' $header | sed 's+(.*+();+;')
+$(grep -E '^[a-z_0-9]+\(' $header | sed 's+(.*+();+;')
 
 }
 EOF


### PR DESCRIPTION
`egrep` has been deprecated in GNU grep since 2007, and since 3.8 it emits obsolescence warnings:
https://git.savannah.gnu.org/cgit/grep.git/commit/?id=a9515624709865d480e3142fd959bccd1c9372d1