### PR TITLE
fix FLR reset callback

### DIFF
--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -270,7 +270,7 @@ handle_px_pxdc_write(vfu_ctx_t *vfu_ctx, struct pxcap *px,
         }
         if (vfu_ctx->reset != NULL) {
             vfu_log(vfu_ctx, LOG_DEBUG, "initiate function level reset");
-            return vfu_ctx->reset(vfu_ctx, VFU_RESET_PCI_FLR);
+	    return call_reset_cb(vfu_ctx, VFU_RESET_PCI_FLR);
         } else {
             vfu_log(vfu_ctx, LOG_ERR, "FLR callback is not implemented");
         }

--- a/lib/private.h
+++ b/lib/private.h
@@ -221,10 +221,10 @@ handle_dma_unmap(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg,
                  struct vfio_user_dma_unmap *dma_unmap);
 
 int
-handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+call_reset_cb(vfu_ctx_t *vfu_ctx, vfu_reset_type_t reason);
 
 int
-handle_device_reset(vfu_ctx_t *vfu_ctx, vfu_reset_type_t reason);
+handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
 
 MOCK_DECLARE(bool, cmd_allowed_when_stopped_and_copying, uint16_t cmd);
 

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -869,6 +869,16 @@ def __dma_unregister(ctx, info):
     dma_unregister(ctx, copy.copy(info.contents))
 
 
+def setup_flrc(ctx):
+    # flrc
+    cap = struct.pack("ccHHcc52c", to_byte(PCI_CAP_ID_EXP), b'\0', 0, 0, b'\0',
+                      b'\x10', *[b'\0' for _ in range(52)])
+    # FIXME adding capability after we've realized the device only works
+    # because of bug #618.
+    pos = vfu_pci_add_capability(ctx, pos=0, flags=0, data=cap)
+    assert pos == PCI_STD_HEADER_SIZEOF
+
+
 def quiesce_cb(ctx):
     return 0
 

--- a/test/py/test_pci_caps.py
+++ b/test/py/test_pci_caps.py
@@ -314,16 +314,6 @@ def __test_pci_cap_write_pmcs(sock):
                  count=len(data), data=data, expect=errno.ENOTSUP)
 
 
-def _setup_flrc(ctx):
-    # flrc
-    cap = struct.pack("ccHHcc52c", to_byte(PCI_CAP_ID_EXP), b'\0', 0, 0, b'\0',
-                      b'\x10', *[b'\0' for _ in range(52)])
-    # FIXME adding capability after we've realized the device only works
-    # because of bug #618.
-    pos = vfu_pci_add_capability(ctx, pos=0, flags=0, data=cap)
-    assert pos == PCI_STD_HEADER_SIZEOF
-
-
 @patch("libvfio_user.reset_cb", return_value=0)
 @patch('libvfio_user.quiesce_cb')
 def test_pci_cap_write_px(mock_quiesce, mock_reset):
@@ -333,7 +323,7 @@ def test_pci_cap_write_px(mock_quiesce, mock_reset):
     setup_pci_dev(realize=True)
     sock = connect_client(ctx)
 
-    _setup_flrc(ctx)
+    setup_flrc(ctx)
 
     # iflr
     offset = PCI_STD_HEADER_SIZEOF + 8
@@ -421,7 +411,7 @@ def test_pci_cap_write_pxdc2():
     setup_pci_dev(realize=True)
     sock = connect_client(ctx)
 
-    _setup_flrc(ctx)
+    setup_flrc(ctx)
 
     offset = (vfu_pci_find_capability(ctx, False, PCI_CAP_ID_EXP) +
               PCI_EXP_DEVCTL2)
@@ -436,9 +426,10 @@ def test_pci_cap_write_pxdc2():
 def test_pci_cap_write_pxlc2():
 
     setup_pci_dev(realize=True)
-    _setup_flrc(ctx)
-
     sock = connect_client(ctx)
+
+    setup_flrc(ctx)
+
     offset = (vfu_pci_find_capability(ctx, False, PCI_CAP_ID_EXP) +
               PCI_EXP_LNKCTL2)
     data = b'\xbe\xef'


### PR DESCRIPTION
A reset callback is allowed to call functions disallowed in quiescent
state. However, the FLR reset path neglected to account for this
properly, causing an incorrect assert to be triggered if, for example,
vfu_sgl_put() is called. To fix this, make sure all reset paths go
through call_reset_cb().

Signed-off-by: John Levon <john.levon@nutanix.com>
