### PR TITLE
test: don't leave global pointing to stack memory

### DIFF
--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -601,6 +601,7 @@ test_device_is_stopped_and_copying(UNUSED void **state)
             assert_false(r);
         }
     }
+    vfu_ctx.migration = NULL;
 }
 
 static void


### PR DESCRIPTION
test_device_is_stopped_and_copying points the global vfu_ctx structure to a local stack-allocated data
structure.  This is fine while the function is
executing, but newer gcc complains that the
pointer is left there after it returns.

So clear the pointer to NULL before returning.

Reported-by: Kamil Godzwon <kamilx.godzwon@intel.com>