### PR TITLE
Adapt to new (v2) VFIO migration interface

### DIFF
--- a/docs/vfio-user.rst
+++ b/docs/vfio-user.rst
@@ -4,7 +4,7 @@ vfio-user Protocol Specification
 ********************************
 
 --------------
-Version_ 0.9.1
+Version_ 0.9.2
 --------------
 
 .. contents:: Table of Contents
@@ -366,6 +366,9 @@ Name                                    Command    Request Direction
 ``VFIO_USER_DMA_WRITE``                 12         server -> client
 ``VFIO_USER_DEVICE_RESET``              13         client -> server
 ``VFIO_USER_REGION_WRITE_MULTI``        15         client -> server
+``VFIO_USER_DEVICE_FEATURE``            16         client -> server
+``VFIO_USER_MIG_DATA_READ``             17         client -> server
+``VFIO_USER_MIG_DATA_WRITE``            18         client -> server
 ======================================  =========  =================
 
 Header
@@ -515,18 +518,7 @@ Capabilities:
 |                    |         | are supported if the value is ``true``.        |
 +--------------------+---------+------------------------------------------------+
 
-The migration capability contains the following name/value pairs:
-
-+-----------------+--------+--------------------------------------------------+
-| Name            | Type   | Description                                      |
-+=================+========+==================================================+
-| pgsize          | number | Page size of dirty pages bitmap. The smallest    |
-|                 |        | between the client and the server is used.       |
-+-----------------+--------+--------------------------------------------------+
-| max_bitmap_size | number | Maximum bitmap size in ``VFIO_USER_DIRTY_PAGES`` |
-|                 |        | and ``VFIO_DMA_UNMAP`` messages.  Optional,      |
-|                 |        | with a default value of 256MB.                   |
-+-----------------+--------+--------------------------------------------------+
+The migration capability is currently an empty object.
 
 Reply
 ^^^^^
@@ -1468,6 +1460,292 @@ Reply
 
 * *wr_cnt* is the number of device writes completed.
 
+``VFIO_USER_DEVICE_FEATURE``
+----------------------------
+
+This command is analogous to ``VFIO_DEVICE_FEATURE``. It is used to get, set, or
+probe feature data of the device.
+
+Request
+^^^^^^^
+
+The request payload for this message is a structure of the following format.
+
++-------+--------+--------------------------------+
+| Name  | Offset | Size                           |
++=======+========+================================+
+| argsz | 0      | 4                              |
++-------+--------+--------------------------------+
+| flags | 4      | 4                              |
++-------+--------+--------------------------------+
+|       | +---------+---------------------------+ |
+|       | | Bit     | Definition                | |
+|       | +=========+===========================+ |
+|       | | 0 to 15 | VFIO_DEVICE_FEATURE_MASK  | |
+|       | +---------+---------------------------+ |
+|       | | 16      | VFIO_DEVICE_FEATURE_GET   | |
+|       | +---------+---------------------------+ |
+|       | | 17      | VFIO_DEVICE_FEATURE_SET   | |
+|       | +---------+---------------------------+ |
+|       | | 18      | VFIO_DEVICE_FEATURE_PROBE | |
+|       | +---------+---------------------------+ |
++-------+--------+--------------------------------+
+| data  | 8      | variable                       |
++-------+--------+--------------------------------+
+
+* *argsz* is the size of the above structure.
+
+* *flags* defines the action to be performed by the server and upon which
+  feature:
+
+  * ``VFIO_DEVICE_FEATURE_MASK`` is the 16-bit feature index of the relevant
+    feature.
+  
+  * ``VFIO_DEVICE_FEATURE_GET`` instructs the server to get the feature data.
+
+  * ``VFIO_DEVICE_FEATURE_SET`` instructs the server to set the feature data to
+    that given in the ``data`` field of the payload.
+
+  * ``VFIO_DEVICE_FEATURE_PROBE`` instructs the server to probe for feature
+    support. If ``VFIO_DEVICE_FEATURE_GET/SET`` are also set, the probe will
+    only return success if all of the indicated methods are supported.
+
+  ``VFIO_DEVICE_FEATURE_GET`` and ``VFIO_DEVICE_FEATURE_SET`` are mutually
+  exclusive, except for use with ``VFIO_DEVICE_FEATURE_PROBE``.
+
+* *data* is specific to the particular feature. It is not used for probing.
+
+This part of the request is analogous to VFIO's ``struct vfio_device_feature``.
+
+Reply
+^^^^^
+
+The reply payload must be the same as the request payload for setting or
+probing a feature. For getting a feature's data, the data is added in the data
+section and its length is added to ``argsz``.
+
+Device Features
+^^^^^^^^^^^^^^^
+
+The only device features supported by vfio-user are those related to migration.
+
+``VFIO_DEVICE_FEATURE_MIGRATION``
+"""""""""""""""""""""""""""""""""
+
+This feature indicates that the device can support the migration API through
+``VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE``. If ``GET`` succeeds, the ``RUNNING``
+and ``ERROR`` states are always supported. Support for additional states is
+indicated via the flags field; at least ``VFIO_MIGRATION_STOP_COPY`` must be
+set.
+
+There is no data field of the request message.
+
+The data field of the reply message is structured as follows:
+
++-------+--------+---------------------------+
+| Name  | Offset | Size                      |
++=======+========+===========================+
+| flags | 0      | 8                         |
++-------+--------+---------------------------+
+|       | +-----+--------------------------+ |
+|       | | Bit | Definition               | |
+|       | +=====+==========================+ |
+|       | | 0   | VFIO_MIGRATION_STOP_COPY | |
+|       | +-----+--------------------------+ |
+|       | | 1   | VFIO_MIGRATION_P2P       | |
+|       | +-----+--------------------------+ |
+|       | | 2   | VFIO_MIGRATION_PRE_COPY  | |
+|       | +-----+--------------------------+ |
++-------+--------+---------------------------+
+
+``VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE``
+""""""""""""""""""""""""""""""""""""""""
+
+Upon ``VFIO_DEVICE_FEATURE_SET``, execute a migration state change on the VFIO
+device. The new state is supplied in ``device_state``. The state transition must
+fully complete before the reply is sent.
+
+The data field of the reply message, as well as the ``SET`` request message, is
+structured as follows:
+
++--------------+--------+------+
+| Name         | Offset | Size |
++==============+========+======+
+| device_state | 0      | 4    |
++--------------+--------+------+
+| data_fd      | 4      + 4    |
++--------------+--------+------+
+
+* *device_state* is the current state of the device (for ``GET``) or the
+  state to transition to (for ``SET``). It is defined by the
+  ``vfio_device_mig_state`` enum as detailed below. These states are the states
+  of the device migration Finite State Machine.
+
++--------------------------------+-------+---------------------------------------------------------------------+
+| Name                           | State | Description                                                         |
++================================+=======+=====================================================================+
+| VFIO_DEVICE_STATE_ERROR        | 0     | The device has failed and must be reset.                            |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_STOP         | 1     | The device does not change the internal or external state.          |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_RUNNING      | 2     | The device is running normally.                                     |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_STOP_COPY    | 3     | The device internal state can be read out.                          |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_RESUMING     | 4     | The device is stopped and is loading a new internal state.          |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_RUNNING_P2P  | 5     | (not used in vfio-user)                                             |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_PRE_COPY     | 6     | The device is running normally but tracking internal state changes. |
++--------------------------------+-------+---------------------------------------------------------------------+
+| VFIO_DEVICE_STATE_PRE_COPY_P2P | 7     | (not used in vfio-user)                                             |
++--------------------------------+-------+---------------------------------------------------------------------+
+
+* *data_fd* is unused in vfio-user, as the ``VFIO_USER_MIG_DATA_READ`` and
+  ``VFIO_USER_MIG_DATA_WRITE`` messages are used instead for migration data
+  transport.
+
+Direct State Transitions
+""""""""""""""""""""""""
+
+The device migration FSM is a Mealy machine, so actions are taken upon the arcs
+between FSM states. The following transitions need to be supported by the
+server, a subset of those defined in ``<linux/vfio.h>``
+(``enum vfio_device_mig_state``).
+
+* ``RUNNING -> STOP``, ``STOP_COPY -> STOP``: Stop the operation of the device. The ``STOP_COPY`` arc terminates the data transfer session.
+
+* ``RESUMING -> STOP``: Terminate the data transfer session. Complete processing
+  of the migration data. Stop the operation of the device. If the delivered data
+  is found to be incomplete, inconsistent, or otherwise invalid, fail the
+  ``SET`` command and optionally transition to the ``ERROR`` state.
+
+* ``PRE_COPY -> RUNNING``: Terminate the data transfer session. The device is
+  now fully operational.
+
+* ``STOP -> RUNNING``: Start the operation of the device.
+
+* ``RUNNING -> PRE_COPY``, ``STOP -> STOP_COPY``: Begin the process of saving
+  the device state. The device operation is unchanged, but data transfer begins.
+  ``PRE_COPY`` and ``STOP_COPY`` are referred to as the "saving group" of
+  states.
+
+* ``PRE_COPY -> STOP_COPY``: Continue to transfer migration data, but stop 
+  device operation.
+
+* ``STOP -> RESUMING``: Start the process of restoring the device state. The
+  internal device state may be changed to prepare the device to receive the
+  migration data.
+
+The ``STOP_COPY -> PRE_COPY`` transition is explicitly not allowed and should
+return an error if requested.
+
+``ERROR`` cannot be specified as a device state, but any transition request can
+be failed and then move the state into ``ERROR`` if the server was unable to
+execute the requested arc AND was unable to restore the device into any valid
+state. To recover from ``ERROR``, ``VFIO_USER_DEVICE_RESET`` must be used to
+return back to ``RUNNING``.
+
+If ``PRE_COPY`` is not supported, arcs touching it are removed.
+
+Complex State Transitions
+"""""""""""""""""""""""""
+
+The remaining possible transitions are to be implemented as combinations of the
+above FSM arcs. As there are multiple paths, the path should be selected based
+on the following rules:
+
+* Select the shortest path.
+
+* The path cannot have saving group states as interior arcs, only start/end
+  states.
+
+``VFIO_USER_MIG_DATA_READ``
+---------------------------
+
+This command is used to read data from the source migration server while it is
+in a saving group state (``PRE_COPY`` or ``STOP_COPY``).
+
+This command, and ``VFIO_USER_MIG_DATA_WRITE``, are used in place of the
+``data_fd`` file descriptor in ``<linux/vfio.h>``
+(``struct vfio_device_feature_mig_state``) to enable all data transport to use
+the single already-established UNIX socket. Hence, the migration data is
+treated like a stream, so the client must continue reading until no more
+migration data remains.
+
+Request
+^^^^^^^
+
+The request payload for this message is a structure of the following format.
+
++-------+--------+------+
+| Name  | Offset | Size |
++=======+========+======+
+| argsz | 0      | 4    |
++-------+--------+------+
+| size  | 4      | 8    |
++-------+--------+------+
+
+* *argsz* is the size of the above structure.
+
+* *size* is the size of the migration data to read.
+
+Reply
+^^^^^
+
+The reply payload for this message is a structure of the following format.
+
++-------+--------+----------+
+| Name  | Offset | Size     |
++=======+========+==========+
+| argsz | 0      | 4        |
++-------+--------+----------+
+| size  | 4      | 8        |
++-------+--------+----------+
+| data  | 12     | variable |
++-------+--------+----------+
+
+* *argsz* is the size of the above structure.
+
+* *size* indicates the size of returned migration data. If this is less than the
+  requested size, there is no more migration data to read.
+
+* *data* contains the migration data.
+
+``VFIO_USER_MIG_DATA_WRITE``
+----------------------------
+
+This command is used to write data to the destination migration server while it
+is in the ``RESUMING`` state.
+
+As above, this replaces the ``data_fd`` file descriptor for transport of
+migration data, and as such, the migration data is treated like a stream.
+
+Request
+^^^^^^^
+
+The request payload for this message is a structure of the following format.
+
++-------+--------+----------+
+| Name  | Offset | Size     |
++=======+========+==========+
+| argsz | 0      | 4        |
++-------+--------+----------+
+| size  | 4      | 8        |
++-------+--------+----------+
+| data  | 12     | variable |
++-------+--------+----------+
+
+* *argsz* is the size of the above structure.
+
+* *size* is the size of the migration data to be written.
+
+* *data* contains the migration data.
+
+Reply
+^^^^^
+
+There is no reply payload for this message.
 
 Appendices
 ==========

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -86,7 +86,11 @@ dma_sg_size(void);
  * reads or writes of the socket connection will not need to block, since both
  * APIS are synchronous.
  */
-#define LIBVFIO_USER_FLAG_ATTACH_NB  (1 << 0)
+#define LIBVFIO_USER_FLAG_ATTACH_NB  (1)
+
+// Should the server start in the migration "RESUMING" state? Given to
+//   init_migration
+#define LIBVFIO_USER_MIG_FLAG_START_RESUMING (1 << 0)
 
 typedef enum {
     VFU_TRANS_SOCK,

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -583,21 +583,8 @@ typedef enum {
     VFU_MIGR_STATE_RESUME
 } vfu_migr_state_t;
 
-#define VFU_MIGR_CALLBACKS_VERS 1
+#define VFU_MIGR_CALLBACKS_VERS 2
 
-/*
- * Callbacks during the pre-copy and stop-and-copy phases.
- *
- * The client executes the following steps to copy migration data:
- *
- * 1. get_pending_bytes: device must return amount of migration data
- * 2. prepare_data: device must prepare migration data
- * 3. read_data: device must provide migration data
- *
- * The client repeats the above steps until there is no more migration data to
- * return (the device must return 0 from get_pending_bytes to indicate that
- * there are no more migration data to be consumed in this iteration).
- */
 typedef struct {
 
     /*
@@ -615,82 +602,12 @@ typedef struct {
      * FIXME maybe we should create a single callback and pass the state?
      */
     int (*transition)(vfu_ctx_t *vfu_ctx, vfu_migr_state_t state);
-
-    /* Callbacks for saving device state */
-
-    /*
-     * Function that is called to retrieve the amount of pending migration
-     * data. If migration data were previously made available (function
-     * prepare_data has been called) then calling this function signifies that
-     * they have been read (e.g. migration data can be discarded). If the
-     * function returns 0 then migration has finished and this function won't
-     * be called again.
-     *
-     * The amount of pending migration data returned by the device does not
-     * necessarily have to monotonically decrease over time and does not need
-     * to match the amount of migration data returned via the @size argument in
-     * prepare_data. It can completely fluctuate according to the needs of the
-     * device. These semantics are derived from the pending_bytes register in
-     * VFIO. Therefore the value returned by get_pending_bytes must be
-     * primarily regarded as boolean, either 0 or non-zero, as far as migration
-     * completion is concerned. More advanced vfio-user clients can make
-     * assumptions on how migration is progressing on devices that guarantee
-     * that the amount of pending migration data decreases over time.
-     */
-    uint64_t (*get_pending_bytes)(vfu_ctx_t *vfu_ctx);
-
-    /*
-     * Function that is called to instruct the device to prepare migration data
-     * to be read when in pre-copy or stop-and-copy state, and to prepare for
-     * receiving migration data when in resuming state.
-     *
-     * When in pre-copy and stop-and-copy state, the function must return only
-     * after migration data are available at the specified offset. This
-     * callback is called once per iteration. The amount of data available
-     * pointed to by @size can be different that the amount of data returned by
-     * get_pending_bytes in the beginning of the iteration.
-     *
-     * In VFIO, the data_offset and data_size registers can be read multiple
-     * times during an iteration and are invariant, libvfio-user simplifies
-     * this by caching the values and returning them when read, guaranteeing
-     * that prepare_data() is called only once per migration iteration.
-     *
-     * When in resuming state, @offset must be set to where migration data must
-     * written. @size points to NULL.
-     *
-     * The callback should return -1 on error, setting errno.
-     */
-    int (*prepare_data)(vfu_ctx_t *vfu_ctx, uint64_t *offset, uint64_t *size);
-
-    /*
-     * Function that is called to read migration data. offset and size can be
-     * any subrange on the offset and size previously returned by prepare_data.
-     * The function must return the amount of data read or -1 on error, setting
-     * errno.
-     *
-     * This function can be called even if the migration data can be memory
-     * mapped.
-     */
+    
     ssize_t (*read_data)(vfu_ctx_t *vfu_ctx, void *buf,
                          uint64_t count, uint64_t offset);
 
-    /* Callbacks for restoring device state */
-
-    /*
-     * Fuction that is called for writing previously stored device state. The
-     * function must return the amount of data written or -1 on error, setting
-     * errno.
-     */
     ssize_t (*write_data)(vfu_ctx_t *vfu_ctx, void *buf, uint64_t count,
                           uint64_t offset);
-
-    /*
-     * Function that is called when client has written some previously stored
-     * device state.
-     *
-     * The callback should return -1 on error, setting errno.
-     */
-    int (*data_written)(vfu_ctx_t *vfu_ctx, uint64_t count);
 
 } vfu_migration_callbacks_t;
 
@@ -722,45 +639,11 @@ _Static_assert(VFIO_DEVICE_STATE_STOP == 0,
 
 #endif /* VFIO_REGION_TYPE_MIGRATION_DEPRECATED */
 
-/*
- * The currently defined migration registers; if using migration callbacks,
- * these are handled internally by the library.
- *
- * This is analogous to struct vfio_device_migration_info.
- */
-struct vfio_user_migration_info {
-    /* VFIO_DEVICE_STATE_* */
-    uint32_t device_state;
-    uint32_t reserved;
-    uint64_t pending_bytes;
-    uint64_t data_offset;
-    uint64_t data_size;
-};
-
-/*
- * Returns the size of the area needed to hold the migration registers at the
- * beginning of the migration region; guaranteed to be page aligned.
- */
-size_t
-vfu_get_migr_register_area_size(void);
-
-/**
- * vfu_setup_device_migration provides an abstraction over the migration
- * protocol: the user specifies a set of callbacks which are called in response
- * to client accesses of the migration region; the migration region read/write
- * callbacks are not called after this function call. Offsets in callbacks are
- * relative to @data_offset.
- *
- * @vfu_ctx: the libvfio-user context
- * @callbacks: migration callbacks
- * @data_offset: offset in the migration region where data begins.
- *
- * @returns 0 on success, -1 on error, sets errno.
- */
 int
 vfu_setup_device_migration_callbacks(vfu_ctx_t *vfu_ctx,
-                                     const vfu_migration_callbacks_t *callbacks,
-                                     uint64_t data_offset);
+                                     uint64_t flags,
+                                     const vfu_migration_callbacks_t
+                                     *callbacks);
 
 /**
  * Triggers an interrupt.
@@ -903,7 +786,6 @@ enum {
     VFU_PCI_DEV_ROM_REGION_IDX,
     VFU_PCI_DEV_CFG_REGION_IDX,
     VFU_PCI_DEV_VGA_REGION_IDX,
-    VFU_PCI_DEV_MIGR_REGION_IDX,
     VFU_PCI_DEV_NUM_REGIONS,
 };
 

--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -603,11 +603,9 @@ typedef struct {
      */
     int (*transition)(vfu_ctx_t *vfu_ctx, vfu_migr_state_t state);
     
-    ssize_t (*read_data)(vfu_ctx_t *vfu_ctx, void *buf,
-                         uint64_t count, uint64_t offset);
+    ssize_t (*read_data)(vfu_ctx_t *vfu_ctx, void *buf, uint64_t count);
 
-    ssize_t (*write_data)(vfu_ctx_t *vfu_ctx, void *buf, uint64_t count,
-                          uint64_t offset);
+    ssize_t (*write_data)(vfu_ctx_t *vfu_ctx, void *buf, uint64_t count);
 
 } vfu_migration_callbacks_t;
 

--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -67,6 +67,7 @@ enum vfio_user_command {
     VFIO_USER_DMA_WRITE                 = 12,
     VFIO_USER_DEVICE_RESET              = 13,
     VFIO_USER_DIRTY_PAGES               = 14,
+    VFIO_USER_DEVICE_FEATURE            = 15,
     VFIO_USER_MAX,
 };
 
@@ -227,6 +228,44 @@ struct vfio_user_bitmap_range {
 #define VFIO_REGION_SUBTYPE_MIGRATION (1)
 
 #endif /* VFIO_REGION_TYPE_MIGRATION */
+
+/* Analogous to vfio_device_feature */
+struct vfio_user_device_feature {
+	uint32_t	argsz;
+	uint32_t	flags;
+#define VFIO_DEVICE_FEATURE_MASK	(0xffff)  /* 16-bit feature index */
+#define VFIO_DEVICE_FEATURE_GET		(1 << 16) /* Get feature into data[] */
+#define VFIO_DEVICE_FEATURE_SET		(1 << 17) /* Set feature from data[] */
+#define VFIO_DEVICE_FEATURE_PROBE	(1 << 18) /* Probe feature support */
+	uint8_t  	data[];
+} __attribute__((packed));
+
+/* Analogous to vfio_device_feature_migration */
+struct vfio_user_device_feature_migration {
+    uint64_t flags;
+#define VFIO_MIGRATION_STOP_COPY    (1 << 0)
+#define VFIO_MIGRATION_P2P          (1 << 1)
+#define VFIO_MIGRATION_PRE_COPY     (1 << 2)
+} __attribute__((packed));
+#define VFIO_DEVICE_FEATURE_MIGRATION 1
+
+/* Analogous to vfio_device_feature_mig_state */
+struct vfio_user_device_feature_mig_state {
+    uint32_t    device_state;
+    uint32_t    data_fd;
+} __attribute__((packed));
+#define VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE 2
+
+enum vfio_device_mig_state {
+	VFIO_DEVICE_STATE_ERROR = 0,
+	VFIO_DEVICE_STATE_STOP = 1,
+	VFIO_DEVICE_STATE_RUNNING = 2,
+	VFIO_DEVICE_STATE_STOP_COPY = 3,
+	VFIO_DEVICE_STATE_RESUMING = 4,
+	VFIO_DEVICE_STATE_RUNNING_P2P = 5,
+	VFIO_DEVICE_STATE_PRE_COPY = 6,
+	VFIO_DEVICE_STATE_PRE_COPY_P2P = 7,
+};
 
 #ifdef __cplusplus
 }

--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -267,13 +267,13 @@ enum vfio_device_mig_state {
 // used for read request and write response
 struct vfio_user_mig_data_without_data {
     uint32_t    argsz;
-    uint32_t    size;
+    uint64_t    size;
 } __attribute__((packed));
 
 // used for write request and read response
 struct vfio_user_mig_data_with_data {
     uint32_t    argsz;
-    uint32_t    size;
+    uint64_t    size;
     uint8_t     data[];
 } __attribute__((packed));
 

--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -66,10 +66,11 @@ enum vfio_user_command {
     VFIO_USER_DMA_READ                  = 11,
     VFIO_USER_DMA_WRITE                 = 12,
     VFIO_USER_DEVICE_RESET              = 13,
-    VFIO_USER_DIRTY_PAGES               = 14,
-    VFIO_USER_DEVICE_FEATURE            = 15,
-    VFIO_USER_MIG_DATA_READ             = 16,
-    VFIO_USER_MIG_DATA_WRITE            = 17,
+    VFIO_USER_DIRTY_PAGES               = 14, // TODO remove
+    VFIO_USER_REGION_WRITE_MULTI        = 15, // TODO implement
+    VFIO_USER_DEVICE_FEATURE            = 16,
+    VFIO_USER_MIG_DATA_READ             = 17,
+    VFIO_USER_MIG_DATA_WRITE            = 18,
     VFIO_USER_MAX,
 };
 

--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -68,6 +68,8 @@ enum vfio_user_command {
     VFIO_USER_DEVICE_RESET              = 13,
     VFIO_USER_DIRTY_PAGES               = 14,
     VFIO_USER_DEVICE_FEATURE            = 15,
+    VFIO_USER_MIG_DATA_READ             = 16,
+    VFIO_USER_MIG_DATA_WRITE            = 17,
     VFIO_USER_MAX,
 };
 
@@ -259,6 +261,21 @@ enum vfio_device_mig_state {
 	VFIO_DEVICE_STATE_PRE_COPY = 6,
 	VFIO_DEVICE_STATE_PRE_COPY_P2P = 7,
 };
+
+// FIXME awful names below
+
+// used for read request and write response
+struct vfio_user_mig_data_without_data {
+    uint32_t    argsz;
+    uint32_t    size;
+} __attribute__((packed));
+
+// used for write request and read response
+struct vfio_user_mig_data_with_data {
+    uint32_t    argsz;
+    uint32_t    size;
+    uint8_t     data[];
+} __attribute__((packed));
 
 #ifdef __cplusplus
 }

--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -222,13 +222,6 @@ struct vfio_user_bitmap_range {
     struct vfio_user_bitmap bitmap;
 } __attribute__((packed));
 
-#ifndef VFIO_REGION_TYPE_MIGRATION
-
-#define VFIO_REGION_TYPE_MIGRATION (3)
-#define VFIO_REGION_SUBTYPE_MIGRATION (1)
-
-#endif /* VFIO_REGION_TYPE_MIGRATION */
-
 /* Analogous to vfio_device_feature */
 struct vfio_user_device_feature {
 	uint32_t	argsz;

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1238,6 +1238,13 @@ handle_request(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
         ret = handle_device_feature(vfu_ctx, msg);
         break;
 
+    case VFIO_USER_MIG_DATA_READ:
+        ret = handle_mig_data_read(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_MIG_DATA_WRITE:
+        ret = handle_mig_data_write(vfu_ctx, msg);
+
     default:
         msg->processed_cmd = false;
         vfu_log(vfu_ctx, LOG_ERR, "bad command %d", msg->hdr.cmd);

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -83,21 +83,16 @@ vfu_log(vfu_ctx_t *vfu_ctx, int level, const char *fmt, ...)
 }
 
 static size_t
-get_vfio_caps_size(bool is_migr_reg, vfu_reg_info_t *reg)
+get_vfio_caps_size(vfu_reg_info_t *reg)
 {
-    size_t type_size = 0;
     size_t sparse_size = 0;
-
-    if (is_migr_reg) {
-        type_size = sizeof(struct vfio_region_info_cap_type);
-    }
 
     if (reg->nr_mmap_areas != 0) {
         sparse_size = sizeof(struct vfio_region_info_cap_sparse_mmap)
                       + (reg->nr_mmap_areas * sizeof(struct vfio_region_sparse_mmap_area));
     }
 
-    return type_size + sparse_size;
+    return sparse_size;
 }
 
 /*
@@ -106,7 +101,7 @@ get_vfio_caps_size(bool is_migr_reg, vfu_reg_info_t *reg)
  * points accordingly.
  */
 static int
-dev_get_caps(vfu_ctx_t *vfu_ctx, vfu_reg_info_t *vfu_reg, bool is_migr_reg,
+dev_get_caps(vfu_ctx_t *vfu_ctx, vfu_reg_info_t *vfu_reg,
              struct vfio_region_info *vfio_reg, int **fds, size_t *nr_fds)
 {
     struct vfio_info_cap_header *header;
@@ -119,16 +114,6 @@ dev_get_caps(vfu_ctx_t *vfu_ctx, vfu_reg_info_t *vfu_reg, bool is_migr_reg,
     assert(nr_fds != NULL);
 
     header = (struct vfio_info_cap_header*)(vfio_reg + 1);
-
-    if (is_migr_reg) {
-        type = (struct vfio_region_info_cap_type *)header;
-        type->header.id = VFIO_REGION_INFO_CAP_TYPE;
-        type->header.version = 1;
-        type->header.next = 0;
-        type->type = VFIO_REGION_TYPE_MIGRATION;
-        type->subtype = VFIO_REGION_SUBTYPE_MIGRATION;
-        vfio_reg->cap_offset = sizeof(struct vfio_region_info);
-    }
 
     if (vfu_reg->mmap_areas != NULL) {
         int i, nr_mmap_areas = vfu_reg->nr_mmap_areas;
@@ -218,14 +203,6 @@ region_access(vfu_ctx_t *vfu_ctx, size_t region, char *buf,
         if (ret == -1) {
             goto out;
         }
-    } else if (region == VFU_PCI_DEV_MIGR_REGION_IDX) {
-        if (vfu_ctx->migration == NULL) {
-            vfu_log(vfu_ctx, LOG_ERR, "migration not enabled");
-            ret = ERROR_INT(EINVAL);
-            goto out;
-        }
-
-        ret = migration_region_access(vfu_ctx, buf, count, offset, is_write);
     } else {
         vfu_region_access_cb_t *cb = vfu_ctx->reg_info[region].cb;
 
@@ -293,8 +270,7 @@ is_valid_region_access(vfu_ctx_t *vfu_ctx, size_t size, uint16_t cmd,
         return false;
     }
 
-    if (unlikely(device_is_stopped_and_copying(vfu_ctx->migration) &&
-        index != VFU_PCI_DEV_MIGR_REGION_IDX)) {
+    if (unlikely(device_is_stopped_and_copying(vfu_ctx->migration))) {
         vfu_log(vfu_ctx, LOG_ERR,
                 "cannot access region %zu while device in stop-and-copy state",
                 index);
@@ -421,8 +397,7 @@ handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     vfu_reg = &vfu_ctx->reg_info[in_info->index];
 
     if (vfu_reg->size > 0) {
-        caps_size = get_vfio_caps_size(in_info->index == VFU_PCI_DEV_MIGR_REGION_IDX,
-                                       vfu_reg);
+        caps_size = get_vfio_caps_size(vfu_reg);
     }
 
     msg->out.iov.iov_len = MIN(sizeof(*out_info) + caps_size, in_info->argsz);
@@ -457,9 +432,8 @@ handle_device_get_region_info(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
         /* Only actually provide the caps if they fit. */
         if (in_info->argsz >= out_info->argsz) {
             out_info->flags |= VFIO_REGION_INFO_FLAG_CAPS;
-            ret = dev_get_caps(vfu_ctx, vfu_reg,
-                               in_info->index == VFU_PCI_DEV_MIGR_REGION_IDX,
-                               out_info, &msg->out.fds, &msg->out.nr_fds);
+            ret = dev_get_caps(vfu_ctx, vfu_reg, out_info, &msg->out.fds,
+                               &msg->out.nr_fds);
             if (ret < 0) {
                 return ret;
             }
@@ -1393,8 +1367,7 @@ static bool
 access_needs_quiesce(const vfu_ctx_t *vfu_ctx, size_t region_index,
                      uint64_t offset)
 {
-    return access_migration_needs_quiesce(vfu_ctx, region_index, offset)
-           || access_is_pci_cap_exp(vfu_ctx, region_index, offset);
+    return access_is_pci_cap_exp(vfu_ctx, region_index, offset);
 }
 
 static bool
@@ -1892,38 +1865,6 @@ copyin_mmap_areas(vfu_reg_info_t *reg_info,
     return 0;
 }
 
-static bool
-ranges_intersect(size_t off1, size_t size1, size_t off2, size_t size2)
-{
-    /*
-     * For two ranges to intersect, the start of each range must be before the
-     * end of the other range.
-     * TODO already defined in lib/pci_caps.c, maybe introduce a file for misc
-     * utility functions?
-     */
-    return (off1 < (off2 + size2) && off2 < (off1 + size1));
-}
-
-static bool
-maps_over_migr_regs(struct iovec *iov)
-{
-    return ranges_intersect(0, vfu_get_migr_register_area_size(),
-                            (size_t)iov->iov_base, iov->iov_len);
-}
-
-static bool
-validate_sparse_mmaps_for_migr_reg(vfu_reg_info_t *reg)
-{
-    int i;
-
-    for (i = 0; i < reg->nr_mmap_areas; i++) {
-        if (maps_over_migr_regs(&reg->mmap_areas[i])) {
-            return false;
-        }
-    }
-    return true;
-}
-
 EXPORT int
 vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
                  vfu_region_access_cb_t *cb, int flags,
@@ -1969,12 +1910,6 @@ vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
         return ERROR_INT(EINVAL);
     }
 
-    if (region_idx == VFU_PCI_DEV_MIGR_REGION_IDX &&
-        size < vfu_get_migr_register_area_size()) {
-        vfu_log(vfu_ctx, LOG_ERR, "invalid migration region size %zu", size);
-        return ERROR_INT(EINVAL);
-    }
-
     for (i = 0; i < nr_mmap_areas; i++) {
         struct iovec *iov = &mmap_areas[i];
         if ((size_t)iov_end(iov) > size) {
@@ -2002,15 +1937,6 @@ vfu_setup_region(vfu_ctx_t *vfu_ctx, int region_idx, size_t size,
     if (nr_mmap_areas > 0) {
         ret = copyin_mmap_areas(reg, mmap_areas, nr_mmap_areas);
         if (ret < 0) {
-            goto err;
-        }
-    }
-
-    if (region_idx == VFU_PCI_DEV_MIGR_REGION_IDX) {
-        if (!validate_sparse_mmaps_for_migr_reg(reg)) {
-            vfu_log(vfu_ctx, LOG_ERR,
-                    "migration registers cannot be memory mapped");
-            errno = EINVAL;
             goto err;
         }
     }
@@ -2093,19 +2019,13 @@ vfu_setup_irq_state_callback(vfu_ctx_t *vfu_ctx, enum vfu_dev_irq_type type,
 }
 
 EXPORT int
-vfu_setup_device_migration_callbacks(vfu_ctx_t *vfu_ctx,
-                                     const vfu_migration_callbacks_t *callbacks,
-                                     uint64_t data_offset)
+vfu_setup_device_migration_callbacks(vfu_ctx_t *vfu_ctx, uint64_t flags,
+                                     const vfu_migration_callbacks_t *callbacks)
 {
     int ret = 0;
 
     assert(vfu_ctx != NULL);
     assert(callbacks != NULL);
-
-    if (vfu_ctx->reg_info[VFU_PCI_DEV_MIGR_REGION_IDX].size == 0) {
-        vfu_log(vfu_ctx, LOG_ERR, "no device migration region");
-        return ERROR_INT(EINVAL);
-    }
 
     if (callbacks->version != VFU_MIGR_CALLBACKS_VERS) {
         vfu_log(vfu_ctx, LOG_ERR, "unsupported migration callbacks version %d",
@@ -2113,7 +2033,7 @@ vfu_setup_device_migration_callbacks(vfu_ctx_t *vfu_ctx,
         return ERROR_INT(EINVAL);
     }
 
-    vfu_ctx->migration = init_migration(callbacks, data_offset, &ret);
+    vfu_ctx->migration = init_migration(callbacks, flags, &ret);
     if (vfu_ctx->migration == NULL) {
         vfu_log(vfu_ctx, LOG_ERR, "failed to initialize device migration");
         return ERROR_INT(ret);

--- a/lib/migration.c
+++ b/lib/migration.c
@@ -42,14 +42,7 @@
 bool
 MOCK_DEFINE(vfio_migr_state_transition_is_valid)(uint32_t from, uint32_t to)
 {
-    return migr_states[from].state & (1 << to);
-}
-
-EXPORT size_t
-vfu_get_migr_register_area_size(void)
-{
-    return ROUND_UP(sizeof(struct vfio_user_migration_info),
-                    sysconf(_SC_PAGE_SIZE));
+    return transitions[from][to];
 }
 
 /*
@@ -57,21 +50,18 @@ vfu_get_migr_register_area_size(void)
  * in vfu_ctx_t.
  */
 struct migration *
-init_migration(const vfu_migration_callbacks_t * callbacks,
-               uint64_t data_offset, int *err)
+init_migration(const vfu_migration_callbacks_t *callbacks,
+               uint64_t flags, int *err)
 {
     struct migration *migr;
-
-    if (data_offset < vfu_get_migr_register_area_size()) {
-        *err = EINVAL;
-        return NULL;
-    }
 
     migr = calloc(1, sizeof(*migr));
     if (migr == NULL) {
         *err = ENOMEM;
         return NULL;
     }
+
+    migr->flags = flags;
 
     /*
      * FIXME: incorrect, if the client doesn't give a pgsize value, it means "no
@@ -81,13 +71,10 @@ init_migration(const vfu_migration_callbacks_t * callbacks,
     migr->pgsize = sysconf(_SC_PAGESIZE);
 
     /* FIXME this should be done in vfu_ctx_realize */
-    migr->info.device_state = VFIO_DEVICE_STATE_V1_RUNNING;
-    migr->data_offset = data_offset;
+    migr->state = VFIO_DEVICE_STATE_RUNNING;
 
     migr->callbacks = *callbacks;
     if (migr->callbacks.transition == NULL ||
-        migr->callbacks.get_pending_bytes == NULL ||
-        migr->callbacks.prepare_data == NULL ||
         migr->callbacks.read_data == NULL ||
         migr->callbacks.write_data == NULL) {
         free(migr);
@@ -100,35 +87,30 @@ init_migration(const vfu_migration_callbacks_t * callbacks,
 
 void
 MOCK_DEFINE(migr_state_transition)(struct migration *migr,
-                                   enum migr_iter_state state)
+                                   enum vfio_device_mig_state state)
 {
     assert(migr != NULL);
     /* FIXME validate that state transition */
-    migr->iter.state = state;
+    migr->state = state;
 }
 
 vfu_migr_state_t
-MOCK_DEFINE(migr_state_vfio_to_vfu)(uint32_t device_state)
+MOCK_DEFINE(migr_state_vfio_to_vfu)(enum vfio_device_mig_state state)
 {
-    switch (device_state) {
-        case VFIO_DEVICE_STATE_V1_STOP:
+    switch (state) {
+        case VFIO_DEVICE_STATE_STOP:
             return VFU_MIGR_STATE_STOP;
-        case VFIO_DEVICE_STATE_V1_RUNNING:
+        case VFIO_DEVICE_STATE_RUNNING:
             return VFU_MIGR_STATE_RUNNING;
-        case VFIO_DEVICE_STATE_V1_SAVING:
-            /*
-             * FIXME How should the device operate during the stop-and-copy
-             * phase? Should we only allow the migration data to be read from
-             * the migration region? E.g. Access to any other region should be
-             * failed? This might be a good question to send to LKML.
-             */
+        case VFIO_DEVICE_STATE_STOP_COPY:
             return VFU_MIGR_STATE_STOP_AND_COPY;
-        case VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING:
-            return VFU_MIGR_STATE_PRE_COPY;
-        case VFIO_DEVICE_STATE_V1_RESUMING:
+        case VFIO_DEVICE_STATE_RESUMING:
             return VFU_MIGR_STATE_RESUME;
+        case VFIO_DEVICE_STATE_PRE_COPY:
+            return VFU_MIGR_STATE_PRE_COPY;
+        default:
+            return -1;
     }
-    return -1;
 }
 
 /**
@@ -165,8 +147,7 @@ MOCK_DEFINE(migr_trans_to_valid_state)(vfu_ctx_t *vfu_ctx, struct migration *mig
             return ret;
         }
     }
-    migr->info.device_state = device_state;
-    migr_state_transition(migr, VFIO_USER_MIGR_ITER_STATE_INITIAL);
+    migr_state_transition(migr, device_state); // TODO confused
     return 0;
 }
 
@@ -180,358 +161,10 @@ MOCK_DEFINE(handle_device_state)(vfu_ctx_t *vfu_ctx, struct migration *migr,
 
     assert(migr != NULL);
 
-    if (!vfio_migr_state_transition_is_valid(migr->info.device_state,
-                                             device_state)) {
+    if (!vfio_migr_state_transition_is_valid(migr->state, device_state)) {
         return ERROR_INT(EINVAL);
     }
     return migr_trans_to_valid_state(vfu_ctx, migr, device_state, notify);
-}
-
-/**
- * Returns 0 on success, -1 on error setting errno.
- */
-static ssize_t
-handle_pending_bytes(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                     uint64_t *pending_bytes, bool is_write)
-{
-    assert(migr != NULL);
-    assert(pending_bytes != NULL);
-
-    if (is_write) {
-        return ERROR_INT(EINVAL);
-    }
-
-    if (migr->iter.state == VFIO_USER_MIGR_ITER_STATE_FINISHED) {
-        *pending_bytes = 0;
-        return 0;
-    }
-
-    switch (migr->iter.state) {
-        case VFIO_USER_MIGR_ITER_STATE_INITIAL:
-        case VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED:
-            /*
-             * FIXME what happens if data haven't been consumed in the previous
-             * iteration? Check https://www.spinics.net/lists/kvm/msg228608.html.
-             */
-            *pending_bytes = migr->iter.pending_bytes = migr->callbacks.get_pending_bytes(vfu_ctx);
-
-            if (*pending_bytes == 0) {
-                migr_state_transition(migr, VFIO_USER_MIGR_ITER_STATE_FINISHED);
-            } else {
-                migr_state_transition(migr, VFIO_USER_MIGR_ITER_STATE_STARTED);
-            }
-            break;
-        case VFIO_USER_MIGR_ITER_STATE_STARTED:
-            /*
-             * FIXME We might be wrong returning a cached value, check
-             * https://www.spinics.net/lists/kvm/msg228608.html
-             *
-             */
-            *pending_bytes = migr->iter.pending_bytes;
-            break;
-        default:
-            return ERROR_INT(EINVAL);
-    }
-    return 0;
-}
-
-/*
- * FIXME reading or writing migration registers with the wrong device state or
- * out of sequence is undefined, but should not result in EINVAL, it should
- * simply be ignored. However this way it's easier to catch development errors.
- * Make this behavior conditional.
- */
-
-/**
- * Returns 0 on success, -1 on error setting errno.
- */
-static ssize_t
-handle_data_offset_when_saving(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                               bool is_write)
-{
-    int ret = 0;
-
-    assert(migr != NULL);
-
-    if (is_write) {
-        vfu_log(vfu_ctx, LOG_ERR, "data_offset is RO when saving");
-        return ERROR_INT(EINVAL);
-    }
-
-    switch (migr->iter.state) {
-    case VFIO_USER_MIGR_ITER_STATE_STARTED:
-        ret = migr->callbacks.prepare_data(vfu_ctx, &migr->iter.offset,
-                                           &migr->iter.size);
-        if (ret != 0) {
-            return ret;
-        }
-        /*
-         * FIXME must first read data_offset and then data_size. They way we've
-         * implemented it now, if data_size is read before data_offset we
-         * transition to state VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED without
-         * calling callbacks.prepare_data, which is wrong. Maybe we need
-         * separate states for data_offset and data_size.
-         */
-        migr_state_transition(migr, VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED);
-        break;
-    case VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED:
-        /*
-         * data_offset is invariant during a save iteration.
-         */
-        break;
-    default:
-        vfu_log(vfu_ctx, LOG_ERR,
-                "reading data_offset out of sequence is undefined");
-        return ERROR_INT(EINVAL);
-    }
-
-    return 0;
-}
-
-/**
- * Returns 0 on success, -1 on error setting errno.
- */
-static ssize_t
-handle_data_offset(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                   uint64_t *offset, bool is_write)
-{
-    int ret;
-
-    assert(migr != NULL);
-    assert(offset != NULL);
-
-    switch (migr->info.device_state) {
-    case VFIO_DEVICE_STATE_V1_SAVING:
-    case VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING:
-        ret = handle_data_offset_when_saving(vfu_ctx, migr, is_write);
-        if (ret == 0 && !is_write) {
-            *offset = migr->iter.offset + migr->data_offset;
-        }
-        return ret;
-    case VFIO_DEVICE_STATE_V1_RESUMING:
-        if (is_write) {
-            /* TODO writing to read-only registers should be simply ignored */
-            vfu_log(vfu_ctx, LOG_ERR, "bad write to migration data_offset");
-            return ERROR_INT(EINVAL);
-        }
-        ret = migr->callbacks.prepare_data(vfu_ctx, offset, NULL);
-        if (ret != 0) {
-            return ret;
-        }
-        *offset += migr->data_offset;
-        return 0;
-    }
-    /* TODO improve error message */
-    vfu_log(vfu_ctx, LOG_ERR,
-            "bad access to migration data_offset in state %s",
-            migr_states[migr->info.device_state].name);
-    return ERROR_INT(EINVAL);
-}
-
-/**
- * Returns 0 on success, -1 on failure setting errno.
- */
-static ssize_t
-handle_data_size_when_saving(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                             bool is_write)
-{
-    assert(migr != NULL);
-
-    if (is_write) {
-        /* TODO improve error message */
-        vfu_log(vfu_ctx, LOG_ERR, "data_size is RO when saving");
-        return ERROR_INT(EINVAL);
-    }
-
-    if (migr->iter.state != VFIO_USER_MIGR_ITER_STATE_STARTED &&
-        migr->iter.state != VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED) {
-        vfu_log(vfu_ctx, LOG_ERR,
-                "reading data_size ouf of sequence is undefined");
-        return ERROR_INT(EINVAL);
-    }
-    return 0;
-}
-
-/**
- * Returns 0 on success, -1 on error setting errno.
- */
-static ssize_t
-handle_data_size_when_resuming(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                               uint64_t size, bool is_write)
-{
-    assert(migr != NULL);
-
-    if (is_write) {
-        return migr->callbacks.data_written(vfu_ctx, size);
-    }
-    return 0;
-}
-
-/**
- * Returns 0 on success, -1 on failure setting errno.
- */
-static ssize_t
-handle_data_size(vfu_ctx_t *vfu_ctx, struct migration *migr,
-                 uint64_t *size, bool is_write)
-{
-    int ret;
-
-    assert(vfu_ctx != NULL);
-    assert(size != NULL);
-
-    switch (migr->info.device_state){
-    case VFIO_DEVICE_STATE_V1_SAVING:
-    case VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING:
-        ret = handle_data_size_when_saving(vfu_ctx, migr, is_write);
-        if (ret == 0 && !is_write) {
-            *size = migr->iter.size;
-        }
-        return ret;
-    case VFIO_DEVICE_STATE_V1_RESUMING:
-        return handle_data_size_when_resuming(vfu_ctx, migr, *size, is_write);
-    }
-    /* TODO improve error message */
-    vfu_log(vfu_ctx, LOG_ERR, "bad access to data_size");
-    return ERROR_INT(EINVAL);
-}
-
-/**
- * Returns 0 on success, -1 on failure setting errno.
- */
-ssize_t
-MOCK_DEFINE(migration_region_access_registers)(vfu_ctx_t *vfu_ctx, char *buf,
-                                               size_t count, loff_t pos,
-                                               bool is_write)
-{
-    struct migration *migr = vfu_ctx->migration;
-    int ret;
-    uint32_t *device_state, old_device_state;
-
-    assert(migr != NULL);
-
-    switch (pos) {
-    case offsetof(struct vfio_user_migration_info, device_state):
-        if (count != sizeof(migr->info.device_state)) {
-            vfu_log(vfu_ctx, LOG_ERR,
-                    "bad device_state access size %zu", count);
-            return ERROR_INT(EINVAL);
-        }
-        device_state = (uint32_t *)buf;
-        if (!is_write) {
-            *device_state = migr->info.device_state;
-            return 0;
-        }
-        old_device_state = migr->info.device_state;
-        vfu_log(vfu_ctx, LOG_DEBUG,
-            "migration: transitioning from state %s to state %s",
-             migr_states[old_device_state].name,
-             migr_states[*device_state].name);
-
-        ret = handle_device_state(vfu_ctx, migr, *device_state, true);
-        if (ret == 0) {
-            vfu_log(vfu_ctx, LOG_DEBUG,
-                "migration: transitioned from state %s to state %s",
-                 migr_states[old_device_state].name,
-                 migr_states[*device_state].name);
-        } else {
-            vfu_log(vfu_ctx, LOG_ERR,
-                "migration: failed to transition from state %s to state %s",
-                 migr_states[old_device_state].name,
-                 migr_states[*device_state].name);
-        }
-        break;
-    case offsetof(struct vfio_user_migration_info, pending_bytes):
-        if (count != sizeof(migr->info.pending_bytes)) {
-            vfu_log(vfu_ctx, LOG_ERR,
-                    "bad pending_bytes access size %zu", count);
-            return ERROR_INT(EINVAL);
-        }
-        ret = handle_pending_bytes(vfu_ctx, migr, (uint64_t *)buf, is_write);
-        break;
-    case offsetof(struct vfio_user_migration_info, data_offset):
-        if (count != sizeof(migr->info.data_offset)) {
-            vfu_log(vfu_ctx, LOG_ERR,
-                    "bad data_offset access size %zu", count);
-            return ERROR_INT(EINVAL);
-        }
-        ret = handle_data_offset(vfu_ctx, migr, (uint64_t *)buf, is_write);
-        break;
-    case offsetof(struct vfio_user_migration_info, data_size):
-        if (count != sizeof(migr->info.data_size)) {
-            vfu_log(vfu_ctx, LOG_ERR,
-                    "bad data_size access size %zu", count);
-            return ERROR_INT(EINVAL);
-        }
-        ret = handle_data_size(vfu_ctx, migr, (uint64_t *)buf, is_write);
-        break;
-    default:
-        vfu_log(vfu_ctx, LOG_ERR,
-                "bad migration region register offset %#llx",
-                (ull_t)pos);
-        return ERROR_INT(EINVAL);
-    }
-    return ret;
-}
-
-ssize_t
-migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
-                        loff_t pos, bool is_write)
-{
-    struct migration *migr = vfu_ctx->migration;
-    ssize_t ret;
-
-    assert(migr != NULL);
-    assert(buf != NULL);
-
-    /*
-     * FIXME don't call the device callback if the migration state is in not in
-     * pre-copy/stop-and-copy/resuming state, since the behavior is undefined
-     * in that case.
-     */
-
-    if (pos + count <= sizeof(struct vfio_user_migration_info)) {
-        ret = migration_region_access_registers(vfu_ctx, buf, count,
-                                                pos, is_write);
-        if (ret != 0) {
-            return ret;
-        }
-    } else {
-
-        if (pos < (loff_t)migr->data_offset) {
-            /*
-             * TODO we can simply ignore the access to that part and handle
-             * any access to the data region properly.
-             */
-            vfu_log(vfu_ctx, LOG_WARNING,
-                    "bad access to dead space %#llx - %#llx in migration region",
-                    (ull_t)pos,
-                    (ull_t)(pos + count - 1));
-            return ERROR_INT(EINVAL);
-        }
-
-        pos -= migr->data_offset;
-        if (is_write) {
-            ret = migr->callbacks.write_data(vfu_ctx, buf, count, pos);
-            if (ret < 0) {
-                return -1;
-            }
-        } else {
-            /*
-             * FIXME <linux/vfio.h> says:
-             *
-             *  d. Read data_size bytes of data from (region + data_offset) from the
-             *     migration region.
-             *
-             * Does this mean that partial reads are not allowed?
-             */
-            ret = migr->callbacks.read_data(vfu_ctx, buf, count, pos);
-            if (ret < 0) {
-                return -1;
-            }
-        }
-    }
-
-    return count;
 }
 
 bool
@@ -563,26 +196,23 @@ migration_feature_get(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf)
 
         case VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE:
             state = buf;
-            state->device_state = vfu_ctx->migration->info.device_state;
+            state->device_state = vfu_ctx->migration->state;
 
             return 0;
 
         default:
             return -EINVAL;
-
     };
 }
 
 ssize_t
-migration_feature_set(UNUSED vfu_ctx_t *vfu_ctx, uint32_t flags,
-                      UNUSED void *buf)
+migration_feature_set(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf)
 {
     if (flags & VFIO_DEVICE_FEATURE_MIG_DEVICE_STATE) {
-        // struct vfio_user_device_feature_mig_state *res = buf;
-
-        // TODO migrate to res->device_state state if allowed to
-
-        return 0;
+        struct vfio_user_device_feature_mig_state *res = buf;
+        struct migration *migr = vfu_ctx->migration;
+        
+        return handle_device_state(vfu_ctx, migr, res->device_state, true);
     }
 
     return -EINVAL;
@@ -591,13 +221,13 @@ migration_feature_set(UNUSED vfu_ctx_t *vfu_ctx, uint32_t flags,
 bool
 MOCK_DEFINE(device_is_stopped_and_copying)(struct migration *migr)
 {
-    return migr != NULL && migr->info.device_state == VFIO_DEVICE_STATE_V1_SAVING;
+    return migr != NULL && migr->state == VFIO_DEVICE_STATE_STOP_COPY;
 }
 
 bool
 MOCK_DEFINE(device_is_stopped)(struct migration *migr)
 {
-    return migr != NULL && migr->info.device_state == VFIO_DEVICE_STATE_V1_STOP;
+    return migr != NULL && migr->state == VFIO_DEVICE_STATE_STOP;
 }
 
 size_t
@@ -620,20 +250,6 @@ migration_set_pgsize(struct migration *migr, size_t pgsize)
 
     migr->pgsize = pgsize;
     return 0;
-}
-
-bool
-access_migration_needs_quiesce(const vfu_ctx_t *vfu_ctx, size_t region_index,
-                              uint64_t offset)
-{
-    /*
-     * Writing to the migration state register with an unaligned access won't
-     * trigger this check but that's not a problem because
-     * migration_region_access_registers will fail the access.
-     */
-    return region_index == VFU_PCI_DEV_MIGR_REGION_IDX
-           && vfu_ctx->migration != NULL
-           && offset == offsetof(struct vfio_user_migration_info, device_state);
 }
 
 /* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -53,6 +53,15 @@ migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
                         loff_t pos, bool is_write);
 
 bool
+migration_feature_supported(uint32_t flags);
+
+ssize_t
+migration_feature_get(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf);
+
+ssize_t
+migration_feature_set(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf);
+
+bool
 migration_available(vfu_ctx_t *vfu_ctx);
 
 MOCK_DECLARE(bool, device_is_stopped, struct migration *migr);

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -79,6 +79,9 @@ migration_set_pgsize(struct migration *migr, size_t pgsize);
 uint64_t
 migration_get_flags(struct migration *migr);
 
+MOCK_DECLARE(void, migr_state_transition, struct migration *migr,
+             enum vfio_device_mig_state state);
+
 MOCK_DECLARE(bool, vfio_migr_state_transition_is_valid, uint32_t from,
              uint32_t to);
 

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -46,11 +46,7 @@
 
 struct migration *
 init_migration(const vfu_migration_callbacks_t *callbacks,
-               uint64_t data_offset, int *err);
-
-ssize_t
-migration_region_access(vfu_ctx_t *vfu_ctx, char *buf, size_t count,
-                        loff_t pos, bool is_write);
+               uint64_t flags, int *err);
 
 bool
 migration_feature_supported(uint32_t flags);
@@ -73,6 +69,9 @@ migration_get_pgsize(struct migration *migr);
 
 int
 migration_set_pgsize(struct migration *migr, size_t pgsize);
+
+uint64_t
+migration_get_flags(struct migration *migr);
 
 MOCK_DECLARE(bool, vfio_migr_state_transition_is_valid, uint32_t from,
              uint32_t to);

--- a/lib/migration.h
+++ b/lib/migration.h
@@ -57,6 +57,12 @@ migration_feature_get(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf);
 ssize_t
 migration_feature_set(vfu_ctx_t *vfu_ctx, uint32_t flags, void *buf);
 
+ssize_t
+handle_mig_data_read(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+
+ssize_t
+handle_mig_data_write(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+
 bool
 migration_available(vfu_ctx_t *vfu_ctx);
 

--- a/lib/migration_priv.h
+++ b/lib/migration_priv.h
@@ -33,93 +33,28 @@
 
 #include <linux/vfio.h>
 
-/*
- * FSM to simplify saving device state.
- */
-enum migr_iter_state {
-    VFIO_USER_MIGR_ITER_STATE_INITIAL,
-    VFIO_USER_MIGR_ITER_STATE_STARTED,
-    VFIO_USER_MIGR_ITER_STATE_DATA_PREPARED,
-    VFIO_USER_MIGR_ITER_STATE_FINISHED
-};
-
 struct migration {
-    /*
-     * TODO if the user provides an FD then should mmap it and use the migration
-     * registers in the file
-     */
-    struct vfio_user_migration_info info;
+    uint64_t flags;
+    enum vfio_device_mig_state state;
     size_t pgsize;
     vfu_migration_callbacks_t callbacks;
-    uint64_t data_offset;
-
-    /*
-     * This is only for the saving state. The resuming state is simpler so we
-     * don't need it.
-     */
-    struct {
-        enum migr_iter_state state;
-        uint64_t pending_bytes;
-        uint64_t offset;
-        uint64_t size;
-    } iter;
 };
 
-struct migr_state_data {
-    uint32_t state;
-    const char *name;
+/* valid migration state transitions 
+   indexed by vfio_device_mig_state enum */
+static const bool transitions[8][8] = {
+    {0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 1, 1, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 1, 0},
+    {0, 1, 0, 0, 0, 0, 0, 0},
+    {0, 1, 0, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0},
+    {0, 0, 1, 0, 0, 0, 0, 0},
+    {0, 0, 0, 0, 0, 0, 0, 0}
 };
-
-#define VFIO_DEVICE_STATE_V1_ERROR (VFIO_DEVICE_STATE_V1_SAVING | VFIO_DEVICE_STATE_V1_RESUMING)
-
-/* valid migration state transitions */
-static const struct migr_state_data migr_states[(VFIO_DEVICE_STATE_MASK + 1)] = {
-    [VFIO_DEVICE_STATE_V1_STOP] = {
-        .state =
-            (1 << VFIO_DEVICE_STATE_V1_STOP) |
-            (1 << VFIO_DEVICE_STATE_V1_RUNNING),
-        .name = "stopped"
-    },
-    [VFIO_DEVICE_STATE_V1_RUNNING] = {
-        .state =
-            (1 << VFIO_DEVICE_STATE_V1_STOP) |
-            (1 << VFIO_DEVICE_STATE_V1_RUNNING) |
-            (1 << VFIO_DEVICE_STATE_V1_SAVING) |
-            (1 << (VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING)) |
-            (1 << VFIO_DEVICE_STATE_V1_RESUMING) |
-            (1 << VFIO_DEVICE_STATE_V1_ERROR),
-        .name = "running"
-    },
-    [VFIO_DEVICE_STATE_V1_SAVING] = {
-        .state =
-            (1 << VFIO_DEVICE_STATE_V1_STOP) |
-            (1 << VFIO_DEVICE_STATE_V1_RUNNING) |
-            (1 << VFIO_DEVICE_STATE_V1_SAVING) |
-            (1 << VFIO_DEVICE_STATE_V1_ERROR),
-        .name = "stop-and-copy"
-    },
-    [VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING] = {
-        .state =
-            (1 << VFIO_DEVICE_STATE_V1_STOP) |
-            (1 << VFIO_DEVICE_STATE_V1_SAVING) |
-            (1 << VFIO_DEVICE_STATE_V1_RUNNING | VFIO_DEVICE_STATE_V1_SAVING) |
-            (1 << VFIO_DEVICE_STATE_V1_ERROR),
-        .name = "pre-copy"
-    },
-    [VFIO_DEVICE_STATE_V1_RESUMING] = {
-        .state =
-            (1 << VFIO_DEVICE_STATE_V1_RUNNING) |
-            (1 << VFIO_DEVICE_STATE_V1_RESUMING) |
-            (1 << VFIO_DEVICE_STATE_V1_ERROR),
-        .name = "resuming"
-    }
-};
-
-MOCK_DECLARE(ssize_t, migration_region_access_registers, vfu_ctx_t *vfu_ctx,
-             char *buf, size_t count, loff_t pos,  bool is_write);
 
 MOCK_DECLARE(void, migr_state_transition, struct migration *migr,
-             enum migr_iter_state state);
+             enum vfio_device_mig_state state);
 
 MOCK_DECLARE(vfu_migr_state_t, migr_state_vfio_to_vfu, uint32_t device_state);
 

--- a/lib/migration_priv.h
+++ b/lib/migration_priv.h
@@ -43,18 +43,15 @@ struct migration {
 /* valid migration state transitions 
    indexed by vfio_device_mig_state enum */
 static const bool transitions[8][8] = {
-    {0, 0, 0, 0, 0, 0, 0, 0},
-    {0, 0, 0, 1, 1, 0, 0, 0},
-    {0, 0, 0, 0, 0, 0, 1, 0},
-    {0, 1, 0, 0, 0, 0, 0, 0},
-    {0, 1, 0, 0, 0, 0, 0, 0},
-    {0, 0, 0, 0, 0, 0, 0, 0},
-    {0, 0, 1, 0, 0, 0, 0, 0},
-    {0, 0, 0, 0, 0, 0, 0, 0}
+    {0, 0, 0, 0, 0, 0, 0, 0}, // ERROR
+    {0, 0, 1, 1, 1, 0, 0, 0}, // STOP
+    {0, 1, 0, 0, 0, 0, 1, 0}, // RUNNING
+    {0, 1, 0, 0, 0, 0, 0, 0}, // STOP_COPY
+    {0, 1, 0, 0, 0, 0, 0, 0}, // RESUMING
+    {0, 0, 0, 0, 0, 0, 0, 0}, // RUNNING_P2P
+    {0, 0, 1, 1, 0, 0, 0, 0}, // PRE_COPY
+    {0, 0, 0, 0, 0, 0, 0, 0}  // PRE_COPY_P2P
 };
-
-MOCK_DECLARE(void, migr_state_transition, struct migration *migr,
-             enum vfio_device_mig_state state);
 
 MOCK_DECLARE(vfu_migr_state_t, migr_state_vfio_to_vfu, uint32_t device_state);
 

--- a/samples/server.c
+++ b/samples/server.c
@@ -62,7 +62,8 @@ struct server_data {
     size_t bar1_size;
     struct dma_regions regions[NR_DMA_REGIONS];
     struct {
-        uint64_t pending_bytes;
+        uint64_t pending_read;
+        uint64_t pending_write;
         vfu_migr_state_t state;
     } migration;
 };
@@ -134,7 +135,7 @@ bar1_access(vfu_ctx_t *vfu_ctx, char * const buf,
     if (is_write) {
         if (server_data->migration.state == VFU_MIGR_STATE_PRE_COPY) {
             /* dirty the whole thing */
-            server_data->migration.pending_bytes = server_data->bar1_size;
+            server_data->migration.pending_read = server_data->bar1_size;
         }
         memcpy(server_data->bar1 + offset, buf, count);
     } else {
@@ -260,19 +261,20 @@ migration_device_state_transition(vfu_ctx_t *vfu_ctx, vfu_migr_state_t state)
             if (setitimer(ITIMER_REAL, &new, NULL) != 0) {
                 err(EXIT_FAILURE, "failed to disable timer");
             }
-            server_data->migration.pending_bytes = server_data->bar1_size + sizeof(time_t); /* FIXME BAR0 region size */
+            server_data->migration.pending_read = server_data->bar1_size + sizeof(time_t); /* FIXME BAR0 region size */
             break;
         case VFU_MIGR_STATE_PRE_COPY:
-            /* TODO must be less than size of data region in migration region */
-            server_data->migration.pending_bytes = server_data->bar1_size;
+            server_data->migration.pending_read = server_data->bar1_size;
             break;
         case VFU_MIGR_STATE_STOP:
             /* FIXME should gracefully fail */
-            assert(server_data->migration.pending_bytes == 0);
+            assert(server_data->migration.pending_read == 0);
             break;
         case VFU_MIGR_STATE_RESUME:
+            server_data->migration.pending_write = server_data->bar1_size + sizeof(time_t);
             break;
         case VFU_MIGR_STATE_RUNNING:
+            assert(server_data->migration.pending_write == 0);
             ret = arm_timer(vfu_ctx, server_data->bar0);
             if (ret < 0) {
                 return ret;
@@ -291,30 +293,59 @@ migration_read_data(vfu_ctx_t *vfu_ctx, void *buf, uint64_t size)
     struct server_data *server_data = vfu_get_private(vfu_ctx);
 
     /*
-     * For ease of implementation we expect the client to read all migration
-     * data in one go; partial reads are not supported. This is allowed by VFIO
-     * however we don't yet support it. Similarly, when resuming, partial
-     * writes are supported by VFIO, however we don't in this sample.
-     *
      * If in pre-copy state we copy BAR1, if in stop-and-copy state we copy
      * both BAR1 and BAR0. Since we always copy BAR1 in the stop-and-copy state,
      * copying BAR1 in the pre-copy state is pointless. Fixing this requires
      * more complex state tracking which exceeds the scope of this sample.
      */
 
-    if (size != server_data->migration.pending_bytes) {
-        errno = EINVAL;
-        return -1;
+    if (server_data->migration.pending_read == 0 || size == 0) {
+        return 0;
     }
 
-    memcpy(buf, server_data->bar1, server_data->bar1_size);
+    uint32_t total_read = server_data->bar1_size;
+
     if (server_data->migration.state == VFU_MIGR_STATE_STOP_AND_COPY) {
-        memcpy(buf + server_data->bar1_size, &server_data->bar0,
-               sizeof(server_data->bar0));
+        total_read += sizeof(server_data->bar0);
     }
-    server_data->migration.pending_bytes = 0;
 
-    return size;
+    uint32_t read_start = total_read - server_data->migration.pending_read;
+    uint32_t read_end = MIN(read_start + size, total_read); // exclusive
+    assert(read_end > read_start);
+
+    uint32_t bytes_read = read_end - read_start;
+
+    if (read_end <= server_data->bar1_size) {
+        // case 1: entire read lies within bar1
+        // TODO check the following is always allowed
+
+        memcpy(buf, server_data->bar1 + read_start, bytes_read);
+    } else if (
+        read_start < server_data->bar1_size // starts in bar1
+        && read_end > server_data->bar1_size // ends in bar0
+    ) {
+        // case 2: part of the read in bar1 and part of the read in bar0
+        // TODO check the following is always allowed
+
+        uint32_t length_in_bar1 = server_data->bar1_size - read_start;
+        uint32_t length_in_bar0 = read_end - server_data->bar1_size;
+        assert(length_in_bar1 + length_in_bar0 == bytes_read);
+        
+        memcpy(buf, server_data->bar1 + read_start, length_in_bar1);
+        memcpy(buf + length_in_bar1, &server_data->bar0, length_in_bar0);
+    } else if (read_start >= server_data->bar1_size) {
+        // case 3: entire read lies within bar0
+        // TODO check the following is always allowed
+
+        read_start -= server_data->bar1_size;
+        read_end -= server_data->bar1_size;
+
+        memcpy(buf, &server_data->bar0 + read_start, bytes_read);
+    }
+
+    server_data->migration.pending_read -= bytes_read;
+
+    return bytes_read;
 }
 
 static ssize_t
@@ -322,34 +353,53 @@ migration_write_data(vfu_ctx_t *vfu_ctx, void *data, uint64_t size)
 {
     struct server_data *server_data = vfu_get_private(vfu_ctx);
     char *buf = data;
-    int ret;
 
     assert(server_data != NULL);
     assert(data != NULL);
 
-    if (size < server_data->bar1_size) {
-        vfu_log(vfu_ctx, LOG_DEBUG, "XXX bad migration data write %#llx-%#llx",
-                (unsigned long long)0,
-                (unsigned long long)size - 1);
-        errno = EINVAL;
-        return -1;
-    }
-
-    memcpy(server_data->bar1, buf, server_data->bar1_size);
-    buf += server_data->bar1_size;
-    size -= server_data->bar1_size;
-    if (size == 0) {
+    if (server_data->migration.pending_write == 0 || size == 0) {
         return 0;
     }
-    if (size != sizeof(server_data->bar0)) {
-        errno = EINVAL;
-        return -1;
-    }
-    memcpy(&server_data->bar0, buf, sizeof(server_data->bar0));
-    ret = bar0_access(vfu_ctx, buf, sizeof(server_data->bar0), 0, true);
-    assert(ret == (int)size); /* FIXME */
 
-    return 0;
+    uint32_t total_write = server_data->bar1_size + sizeof(server_data->bar0);
+
+    uint32_t write_start = total_write - server_data->migration.pending_write;
+    uint32_t write_end = MIN(write_start + size, total_write); // exclusive
+    assert(write_end > write_start);
+
+    uint32_t bytes_written = write_end - write_start;
+
+    if (write_end <= server_data->bar1_size) {
+        // case 1: entire write lies within bar1
+        // TODO check the following is always allowed
+
+        memcpy(server_data->bar1 + write_start, buf, bytes_written);
+    } else if (
+        write_start < server_data->bar1_size // starts in bar1
+        && write_end > server_data->bar1_size // ends in bar0
+    ) {
+        // case 2: part of the write in bar1 and part of the write in bar0
+        // TODO check the following is always allowed
+
+        uint32_t length_in_bar1 = server_data->bar1_size - write_start;
+        uint32_t length_in_bar0 = write_end - server_data->bar1_size;
+        assert(length_in_bar1 + length_in_bar0 == bytes_written);
+        
+        memcpy(server_data->bar1 + write_start, buf, length_in_bar1);
+        memcpy(&server_data->bar0, buf + length_in_bar1, length_in_bar0);
+    } else if (write_start >= server_data->bar1_size) {
+        // case 3: entire write lies within bar0
+        // TODO check the following is always allowed
+
+        write_start -= server_data->bar1_size;
+        write_end -= server_data->bar1_size;
+
+        memcpy(&server_data->bar0 + write_start, buf, bytes_written);
+    }
+
+    server_data->migration.pending_write -= bytes_written;
+
+    return bytes_written;
 }
 
 int main(int argc, char *argv[])
@@ -357,6 +407,7 @@ int main(int argc, char *argv[])
     char template[] = "/tmp/libvfio-user.XXXXXX";
     int ret;
     bool verbose = false;
+    bool destination = false;
     int opt;
     struct sigaction act = {.sa_handler = _sa_handler};
     const size_t bar1_size = 0x3000;
@@ -375,13 +426,19 @@ int main(int argc, char *argv[])
         .write_data = &migration_write_data
     };
 
-    while ((opt = getopt(argc, argv, "v")) != -1) {
+    while ((opt = getopt(argc, argv, "vr")) != -1) {
         switch (opt) {
             case 'v':
                 verbose = true;
                 break;
+            case 'r':
+                destination = true;
+                server_data.migration.state = VFU_MIGR_STATE_RESUME;
+                server_data.migration.pending_write =
+                    bar1_size + sizeof(time_t);
+                break;
             default: /* '?' */
-                errx(EXIT_FAILURE, "Usage: %s [-v] <socketpath>", argv[0]);
+                errx(EXIT_FAILURE, "Usage: %s [-v] [-r] <socketpath>", argv[0]);
         }
     }
 
@@ -459,7 +516,12 @@ int main(int argc, char *argv[])
         err(EXIT_FAILURE, "failed to setup BAR1 region");
     }
 
-    ret = vfu_setup_device_migration_callbacks(vfu_ctx, 0, &migr_callbacks);
+    ret = vfu_setup_device_migration_callbacks(
+        vfu_ctx,
+        destination ? LIBVFIO_USER_MIG_FLAG_START_RESUMING : 0,
+        &migr_callbacks
+    );
+    
     if (ret < 0) {
         err(EXIT_FAILURE, "failed to setup device migration");
     }

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -124,6 +124,16 @@ VFIO_DEVICE_STATE_V1_SAVING = (1 << 1)
 VFIO_DEVICE_STATE_V1_RESUMING = (1 << 2)
 VFIO_DEVICE_STATE_MASK = ((1 << 3) - 1)
 
+VFIO_DEVICE_FEATURE_MIGRATION = (1)
+VFIO_DEVICE_FEATURE_MASK = (0xffff)
+VFIO_DEVICE_FEATURE_GET = (1 << 16)
+VFIO_DEVICE_FEATURE_SET = (1 << 17)
+VFIO_DEVICE_FEATURE_PROBE = (1 << 18)
+
+VFIO_MIGRATION_STOP_COPY = (1 << 0)
+VFIO_MIGRATION_P2P = (1 << 1)
+VFIO_MIGRATION_PRE_COPY = (1 << 2)
+
 
 # libvfio-user defines
 
@@ -171,7 +181,8 @@ VFIO_USER_DMA_READ = 11
 VFIO_USER_DMA_WRITE = 12
 VFIO_USER_DEVICE_RESET = 13
 VFIO_USER_DIRTY_PAGES = 14
-VFIO_USER_MAX = 15
+VFIO_USER_DEVICE_FEATURE = 15
+VFIO_USER_MAX = 16
 
 VFIO_USER_F_TYPE_COMMAND = 0
 VFIO_USER_F_TYPE_REPLY = 1
@@ -568,6 +579,13 @@ class dma_sg_t(Structure):
         return "DMA addr=%s, region index=%s, length=%s, offset=%s, RW=%s" % \
             (hex(self.dma_addr), self.region, hex(self.length),
                 hex(self.offset), self.writeable)
+
+class vfio_user_device_feature(Structure):
+    _pack_ = 1
+    _fields_ = [
+        ("argsz", c.c_uint32),
+        ("flags", c.c_uint32)
+    ]
 
 
 class vfio_user_migration_info(Structure):


### PR DESCRIPTION
This PR will (when done):

- [x] Update to version of the spec as submitted to [qemu-devel](https://lists.nongnu.org/archive/html/qemu-devel/2023-06/msg06567.html)
- [x] Add new migration protocol based on VFIO migration v2, replacing the migration region with a more intuitive stream-like mechanism for transferring migration data (alongside other changes)
- [ ] Implement the new protocol in libvfio-user
- [ ] Update and add more tests for the new protocol
- [ ] Update the samples for the new protocol

Closes #654 