### PR TITLE
fix: server sample not marking dirty pages

### DIFF
--- a/samples/client.c
+++ b/samples/client.c
@@ -1233,11 +1233,7 @@ int main(int argc, char *argv[])
         get_dirty_bitmap(sock, &dma_regions[i], &some_dirty);
     }
 
-    if (some_dirty) {
-        printf("client: server dirtied some pages\n");
-    } else {
-        err(EXIT_FAILURE, "no dirty pages logged");
-    }
+    assert(some_dirty);
 
     dirty_pages.argsz = sizeof(dirty_pages);
     dirty_pages.flags = VFIO_IOMMU_DIRTY_PAGES_FLAG_STOP;

--- a/samples/client.c
+++ b/samples/client.c
@@ -725,6 +725,8 @@ get_dirty_bitmap(int sock, struct vfio_user_dma_map *dma_region, bool *some_dirt
            (ull_t)range->iova,
            (ull_t)(range->iova + range->size - 1), bitmap[0]);
 
+    // We only ever dirty one of the first 8 pages of the region.
+    // See the assertion in `do_dma_io` (server.c).
     if (bitmap[0] != 0) {
         *some_dirty = true;
     }

--- a/samples/server.c
+++ b/samples/server.c
@@ -222,6 +222,7 @@ static void do_dma_io(vfu_ctx_t *vfu_ctx, struct server_data *server_data)
         if (ret < 0) {
             err(EXIT_FAILURE, "vfu_sgl_write failed");
         }
+        vfu_sgl_mark_dirty(vfu_ctx, sg, 1);
     }
 
     crc1 = rte_hash_crc(buf, sizeof(buf), 0);

--- a/samples/server.c
+++ b/samples/server.c
@@ -200,6 +200,7 @@ static void do_dma_io(vfu_ctx_t *vfu_ctx, struct server_data *server_data)
     uint32_t crc1, crc2;
     dma_sg_t *sg;
     void *addr;
+    int max_page_idx;
     int ret;
 
     sg = alloca(dma_sg_size());
@@ -222,6 +223,10 @@ static void do_dma_io(vfu_ctx_t *vfu_ctx, struct server_data *server_data)
         if (ret < 0) {
             err(EXIT_FAILURE, "vfu_sgl_write failed");
         }
+
+        // Assert that we are only dirtying one of the region's first 8 pages.
+        max_page_idx = ((i + 1) * size + PAGE_SIZE - 1) / PAGE_SIZE;
+        assert(max_page_idx < 8);
         vfu_sgl_mark_dirty(vfu_ctx, sg, 1);
     }
 

--- a/samples/server.c
+++ b/samples/server.c
@@ -238,12 +238,11 @@ static void do_dma_io(vfu_ctx_t *vfu_ctx, struct server_data *server_data,
             assert(iov.iov_len == (size_t)size);
             memcpy(iov.iov_base, &buf[i * size], size);
 
-            
             /*
-             * When directly writing to client memory we are responsible for
-             * tracking dirty pages. We assert that all dirty writes are within
-             * the first page of region 1. In fact, all regions are only one
-             * page in size.
+             * When directly writing to client memory the server is responsible
+             * for tracking dirty pages. We assert that all dirty writes are
+             * within the first page of region 1. In fact, all regions are only
+             * one page in size.
              * 
              * Note: this is not strictly necessary in this example, since we
              * later call `vfu_sgl_put`, which marks pages dirty if the SGL was

--- a/samples/server.c
+++ b/samples/server.c
@@ -248,7 +248,7 @@ static void do_dma_io(vfu_ctx_t *vfu_ctx, struct server_data *server_data,
              * later call `vfu_sgl_put`, which marks pages dirty if the SGL was
              * acquired with `PROT_WRITE`. However, `vfu_sgl_mark_dirty` is
              * useful in cases where the server needs to mark guest memory dirty
-             * without releasing the memory.
+             * without releasing the memory with `vfu_sgl_put`.
              */
             vfu_sgl_mark_dirty(vfu_ctx, sg, 1);
             assert(region == 1);


### PR DESCRIPTION
The server sample is supposed to demonstrate dirty page logging, but it was not marking dirty pages. This commit both adds client-side dirty page tracking for pages dirtied with `vfu_sgl_write` and server-side dirty page tracking for pages directly dirtied by the server using `vfu_sgl_get/put`.