### PR TITLE
remove need for mutex in client sample

### DIFF
--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -78,10 +78,7 @@ tran_sock_send_iovec(int sock, uint16_t msg_id, bool is_reply,
     } else {
         hdr.cmd = cmd;
         hdr.flags.type = VFIO_USER_F_TYPE_COMMAND;
-
-        if (no_reply) {
-            hdr.flags.no_reply = true;
-        }
+        hdr.flags.no_reply = no_reply;
     }
 
     iovecs[0].iov_base = &hdr;

--- a/lib/tran_sock.h
+++ b/lib/tran_sock.h
@@ -52,7 +52,8 @@ extern struct transport_ops tran_sock_ops;
 int
 tran_sock_send_iovec(int sock, uint16_t msg_id, bool is_reply,
                      enum vfio_user_command cmd, struct iovec *iovecs,
-                     size_t nr_iovecs, int *fds, int count, int err);
+                     size_t nr_iovecs, int *fds, int count, int err,
+                     bool no_reply);
 
 /*
  * Send a message to the other end with the given data.


### PR DESCRIPTION
For writes to BAR1 (which come from the fake guest thread), we now send the command with the `no_reply` flag set so we don't interfere with the main thread. This means we don't require a mutex.