### PR TITLE
Allow adding MSI capability via vfu_pci_add_capability

### DIFF
--- a/include/libvfio-user.h
+++ b/include/libvfio-user.h
@@ -981,6 +981,7 @@ vfu_pci_get_config_space(vfu_ctx_t *vfu_ctx);
  * Certain standard capabilities are handled entirely within the library:
  *
  * PCI_CAP_ID_EXP (pxcap)
+ * PCI_CAP_ID_MSI (msicap)
  * PCI_CAP_ID_MSIX (msixcap)
  * PCI_CAP_ID_PM (pmcap)
  *

--- a/include/pci_caps/msi.h
+++ b/include/pci_caps/msi.h
@@ -57,6 +57,8 @@ struct ma {
 } __attribute__ ((packed));
 _Static_assert(sizeof(struct ma) == 0x4, "bad MA size");
 
+#define VFIO_USER_PCI_CAP_MSI_SIZEOF (0x18)
+
 struct msicap {
     struct cap_hdr hdr;
     struct mc mc;
@@ -67,7 +69,8 @@ struct msicap {
     uint32_t mmask;         /* RW */
     uint32_t mpend;         /* RO */
 }  __attribute__ ((packed));
-_Static_assert(sizeof(struct msicap) == 0x18, "bad MSICAP size");
+_Static_assert(sizeof(struct msicap) == VFIO_USER_PCI_CAP_MSI_SIZEOF,
+        "bad MSICAP size");
 _Static_assert(offsetof(struct msicap, hdr) == 0, "bad offset");
 
 #ifdef __cplusplus

--- a/include/pci_caps/msi.h
+++ b/include/pci_caps/msi.h
@@ -39,19 +39,21 @@
 extern "C" {
 #endif
 
+/* Message Control for MSI */
 struct mc {
-    unsigned int msie:1;
-    unsigned int mmc:3;
-    unsigned int mme:3;
-    unsigned int c64:1;
-    unsigned int pvm:1;
-    unsigned int res1:7;
+    unsigned int msie:1;    /* RW */
+    unsigned int mmc:3;     /* RO */
+    unsigned int mme:3;     /* RW */
+    unsigned int c64:1;     /* RO */
+    unsigned int pvm:1;     /* RO */
+    unsigned int res1:7;    /* not implemented, extended message data control */
 } __attribute__ ((packed));
 _Static_assert(sizeof(struct mc) == 0x2, "bad MC size");
 
+/* Message Address for MSI */
 struct ma {
-    unsigned int res1:2;
-    unsigned int addr:30;
+    unsigned int res1:2;    /* read must return 0, write has no effect */
+    unsigned int addr:30;   /* RW */
 } __attribute__ ((packed));
 _Static_assert(sizeof(struct ma) == 0x4, "bad MA size");
 
@@ -59,11 +61,11 @@ struct msicap {
     struct cap_hdr hdr;
     struct mc mc;
     struct ma ma;
-    uint32_t mua;
-    uint16_t md;
-    uint16_t padding;
-    uint32_t mmask;
-    uint32_t mpend;
+    uint32_t mua;           /* RW */
+    uint16_t md;            /* RW */
+    uint16_t padding;       /* not implemented, extended message data */
+    uint32_t mmask;         /* RW */
+    uint32_t mpend;         /* RO */
 }  __attribute__ ((packed));
 _Static_assert(sizeof(struct msicap) == 0x18, "bad MSICAP size");
 _Static_assert(offsetof(struct msicap, hdr) == 0, "bad offset");

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -178,9 +178,52 @@ cap_write_msi(vfu_ctx_t *vfu_ctx, struct pci_cap *cap, char *buf,
     memcpy((char *)&new_msi + offset - cap->off, buf, count);
 
     if (msi->mc.msie != new_msi.mc.msie) {
+        msi->mc.msie = new_msi.mc.msie;
         vfu_log(vfu_ctx, LOG_DEBUG, "%s MSI",
                 msi->mc.msie ? "enable" : "disable");
-        msi->mc.msie = new_msi.mc.msie;
+    }
+
+    if (msi->mc.mme != new_msi.mc.mme) {
+        if (new_msi.mc.mme > 5) {
+            vfu_log(vfu_ctx, LOG_ERR,
+                    "MSI cannot have more than 32 interrupt vectors");
+            return ERROR_INT(EINVAL);
+        }
+
+        if (new_msi.mc.mme > msi->mc.mmc) {
+            vfu_log(vfu_ctx, LOG_ERR,
+                    "MSI cannot have more interrupt vectors"
+                    " in MME than defined in MMC");
+            return ERROR_INT(EINVAL);
+        }
+        msi->mc.mme = new_msi.mc.mme;
+
+        vfu_log(vfu_ctx, LOG_DEBUG,
+                "MSI Updated Multiple Message Enable count");
+    }
+
+    if (msi->ma.addr != new_msi.ma.addr) {
+        msi->ma.addr = new_msi.ma.addr;
+        vfu_log(vfu_ctx, LOG_DEBUG,
+                "MSI Message Address set to %x", msi->ma.addr << 2);
+    }
+
+    if (msi->mua != new_msi.mua) {
+        msi->mua = new_msi.mua;
+        vfu_log(vfu_ctx, LOG_DEBUG,
+                "MSI Message Upper Address set to %x", msi->mua);
+    }
+
+    if (msi->md != new_msi.md) {
+        msi->md = new_msi.md;
+        vfu_log(vfu_ctx, LOG_DEBUG,
+                "MSI Message Data set to %x", msi->md);
+    }
+
+    if (msi->mmask != new_msi.mmask) {
+        msi->mmask = new_msi.mmask;
+        vfu_log(vfu_ctx, LOG_DEBUG,
+                "MSI Mask Bits set to %x", msi->mmask);
     }
 
     return count;

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -100,7 +100,7 @@ cap_size(vfu_ctx_t *vfu_ctx, void *data, bool extended)
         case PCI_CAP_ID_EXP:
             return VFIO_USER_PCI_CAP_EXP_SIZEOF;
         case PCI_CAP_ID_MSI:
-            return 0x18;
+            return VFIO_USER_PCI_CAP_MSI_SIZEOF;
         case PCI_CAP_ID_MSIX:
             return PCI_CAP_MSIX_SIZEOF;
         case PCI_CAP_ID_VNDR:

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -70,6 +70,7 @@ PCI_CAP_LIST_NEXT = 1
 
 PCI_CAP_ID_PM = 0x1
 PCI_CAP_ID_VNDR = 0x9
+PCI_CAP_ID_MSI = 0x5
 PCI_CAP_ID_MSIX = 0x11
 PCI_CAP_ID_EXP = 0x10
 
@@ -82,6 +83,12 @@ PCI_EXT_CAP_ID_VNDR = 0x0b
 PCI_EXT_CAP_DSN_SIZEOF = 12
 
 PCI_EXT_CAP_VNDR_HDR_SIZEOF = 8
+
+# MSI registers
+PCI_MSI_FLAGS = 2  # Message Control offset
+PCI_MSI_ADDRESS_LO = 4  # Message Address offset
+PCI_MSI_FLAGS_ENABLE = 0x0001  # MSI enable
+PCI_CAP_MSI_SIZEOF = 24  # size of MSI registers
 
 # MSI-X registers
 PCI_MSIX_FLAGS = 2  # Message Control


### PR DESCRIPTION
Currently `vfu_pci_add_capability(...)` does not allow adding the MSI capability, only MSIX and a handful of other capabilities, even though the MSI capability definition is already present in [include/pci_caps/msi.h](https://github.com/nutanix/libvfio-user/blob/master/include/pci_caps/msi.h).

The new `cap_write_msi` callback function is copied from `cap_write_msix` and adjusted to msicap, omitting the "function mask" bit which is not present in MSI's message control.

The size of the MSI capability does not seem to be defined in pci_regs, just like in
https://github.com/nutanix/libvfio-user/blob/8872c36d5047e464952d8aa7f3f12633357d758d/include/pci_caps/msi.h#L68
compared to:
https://github.com/nutanix/libvfio-user/blob/8872c36d5047e464952d8aa7f3f12633357d758d/include/pci_caps/msix.h#L72