### PR TITLE
Fix MSI-X capability write logging opposite status

### DIFF
--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -182,7 +182,7 @@ cap_write_msix(vfu_ctx_t *vfu_ctx, struct pci_cap *cap, char *buf,
 
     if (msix->mxc.fm != new_msix.mxc.fm) {
         msix->mxc.fm = new_msix.mxc.fm;
-        if (new_msix.mxc.fm) {
+        if (msix->mxc.fm) {
             vfu_log(vfu_ctx, LOG_DEBUG, "all MSI-X vectors masked");
         } else {
             vfu_log(vfu_ctx, LOG_DEBUG,

--- a/lib/pci_caps.c
+++ b/lib/pci_caps.c
@@ -181,19 +181,19 @@ cap_write_msix(vfu_ctx_t *vfu_ctx, struct pci_cap *cap, char *buf,
      */
 
     if (msix->mxc.fm != new_msix.mxc.fm) {
+        msix->mxc.fm = new_msix.mxc.fm;
         if (new_msix.mxc.fm) {
             vfu_log(vfu_ctx, LOG_DEBUG, "all MSI-X vectors masked");
         } else {
             vfu_log(vfu_ctx, LOG_DEBUG,
                    "vector's mask bit determines whether vector is masked");
         }
-        msix->mxc.fm = new_msix.mxc.fm;
     }
 
     if (msix->mxc.mxe != new_msix.mxc.mxe) {
+        msix->mxc.mxe = new_msix.mxc.mxe;
         vfu_log(vfu_ctx, LOG_DEBUG, "%s MSI-X",
                 msix->mxc.mxe ? "enable" : "disable");
-        msix->mxc.mxe = new_msix.mxc.mxe;
     }
 
     return count;


### PR DESCRIPTION
Since the vfu_log call for whether MSI-X is enabled or not is using the not yet updated `msix->mxc.mxe`, it will always print the opposite value. ("enable MSI-X" <-> "disable MSI-X")

Instead of changing it to `new_msix.mxc.mxe`, I simply moved the assignment of both the `mxe` and the unaffected `fm` field before their log calls, so both variants are fine to use.

This is also how other functions like `handle_px_pxdc_write` do it, assignment before log.