### PR TITLE
Add another lspci test output variant

### DIFF
--- a/test/lspci.expected.out.4
+++ b/test/lspci.expected.out.4
@@ -1,0 +1,30 @@
+00:00.0 Non-VGA unclassified device: Device 0000:0000
+	Control: I/O- Mem- BusMaster- SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
+	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
+	Region 0: I/O ports at <unassigned> [disabled]
+	Region 1: I/O ports at <unassigned> [disabled]
+	Region 2: I/O ports at <unassigned> [disabled]
+	Region 3: I/O ports at <unassigned> [disabled]
+	Region 4: I/O ports at <unassigned> [disabled]
+	Region 5: I/O ports at <unassigned> [disabled]
+	Capabilities: [40] Power Management version 0
+		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0-,D1-,D2-,D3hot-,D3cold-)
+		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
+	Capabilities: [48] Vendor Specific Information: Len=10 <?>
+	Capabilities: [58] Express (v0) Endpoint, MSI 00
+		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset+ SlotPowerLimit 0W
+		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop- FLReset-
+			MaxPayload 128 bytes, MaxReadReq 128 bytes
+		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
+		LnkCap:	Port #0, Speed unknown, Width x0, ASPM not supported
+			ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp-
+		LnkCtl:	ASPM Disabled; RCB 64 bytes, Disabled- CommClk-
+			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt-
+		LnkSta:	Speed unknown, Width x0
+			TrErr- Train- SlotClk- DLActive- BWMgmt- ABWMgmt-
+	Capabilities: [100 v0] Device Serial Number ca-fe-ba-be-de-ad-be-ef
+	Capabilities: [10c v0] Vendor Specific Information: ID=0001 Rev=1 Len=015 <?>
+	Capabilities: [400 v0] Vendor Specific Information: ID=0002 Rev=2 Len=015 <?>
+

--- a/test/test-lspci.sh
+++ b/test/test-lspci.sh
@@ -16,7 +16,7 @@ test -n "$1" && LSPCI="$1"
 
 $LSPCI | lspci -vv -F /dev/stdin >lspci.out
 
-for i in 1 2 3; do
+for i in 1 2 3 4; do
     if diff lspci.out $(dirname $0)/lspci.expected.out.$i >/dev/null 2>&1; then
         exit 0
     fi


### PR DESCRIPTION
On my Arch-based systems (Linux 6.1.44-lts) with pciutils 3.10.0 the lspci output is a little different causing the lspci test to fail. Do/Did you test it on a different version of pciutils, or is lspci just that on different distros?

Anyway I added the output I'm getting as and altered the test script accordingly.