### PR TITLE
More Distros for Pull-Request Workflow

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -108,6 +108,9 @@ branches:
           - ubuntu-20
           - ubuntu-22
           - fedora-35
+          - debian-11
+          - debian-12
+          - arch-202307
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -9,7 +9,7 @@ jobs:
     timeout-minutes: 5
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: run-scan
         run: |
           sudo apt-get update

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -5,7 +5,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: pre-push
         run: |
           sudo apt-get update
@@ -17,7 +17,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: pre-push
         run: |
           sudo apt-get update
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: pre-push
         run: |
           # NB: no working flake8
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:35
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: pre-push
         run: |
           dnf -y install --releasever=35 \
@@ -55,6 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     container: vlajos/misspell-fixer
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: run misspell-fixer
         run: /misspell-fixer/misspell-fixer -sv .

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -51,6 +51,47 @@ jobs:
               diffutils valgrind python3-pytest python3-flake8 which \
               meson ninja-build
           ./.github/workflows/pull_request.sh
+  debian-11:
+    timeout-minutes: 10
+    runs-on: ubuntu-20.04
+    container: debian:11
+    steps:
+      - uses: actions/checkout@v3
+      - name: pre-push
+        run: |
+          apt-get update
+          apt-get -y install build-essential cmake pkg-config libjson-c-dev \
+            libcmocka-dev clang clang-tools valgrind python3-pytest \
+            debianutils flake8 meson ninja-build
+          ./.github/workflows/pull_request.sh
+  debian-12:
+    timeout-minutes: 10
+    runs-on: ubuntu-22.04
+    container: debian:12
+    steps:
+      - uses: actions/checkout@v3
+      - name: pre-push
+        run: |
+          apt-get update
+          apt-get -y install build-essential cmake pkg-config libjson-c-dev \
+            libcmocka-dev clang clang-tools valgrind python3-pytest \
+            debianutils flake8 meson ninja-build
+          ./.github/workflows/pull_request.sh
+  arch-202307:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    container: archlinux:base-20230723.0.166908
+    steps:
+      - uses: actions/checkout@v3
+      - name: pre-push
+        run: |
+          # clang expects a newer glibc
+          pacman -Sy --noconfirm \
+            base-devel glibc clang json-c cmocka pciutils diffutils valgrind \
+            python-pytest flake8 meson ninja
+          # this fixes debuginfod not automatically updating the url
+          export DEBUGINFOD_URLS="https://debuginfod.archlinux.org"
+          ./.github/workflows/pull_request.sh
   spelling:
     runs-on: ubuntu-latest
     container: vlajos/misspell-fixer

--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -315,7 +315,7 @@ class iovec_t(Structure):
     ]
 
     def __eq__(self, other):
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
         return self.iov_base == other.iov_base \
             and self.iov_len == other.iov_len
@@ -491,7 +491,7 @@ class vfu_dma_info_t(Structure):
     ]
 
     def __eq__(self, other):
-        if type(self) != type(other):
+        if type(self) is not type(other):
             return False
         return self.iova == other.iova \
             and self.vaddr == other.vaddr \


### PR DESCRIPTION
This does three things:

1. As suggested in #761 this adds a job for Arch Linux (base 20230723.0.166908), but since I was already at it also Debian 11 bullseye and Debian 12 bookworm, to the pull request workflow. 

2. During testing I stumbled across a linting error thrown by the newer flake8 version in the Arch job, see
![Screenshot from 2023-08-15 16-06-34](https://github.com/nutanix/libvfio-user/assets/49617392/fc180055-e206-4eda-9066-8a35149211f3)
I altered the mentioned equality checks in `test/py/libvfio_user.py` to fix this.

3. It also bumps the version of Github Actions to v3 in all workflows. v2 will apparently be deprecated over the summer, see https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/ and
![Screenshot from 2023-08-15 16-36-55](https://github.com/nutanix/libvfio-user/assets/49617392/bafee234-8246-4d77-8714-74795addbeda)

I already tested this on my own runner, see https://github.com/gierens/libvfio-user/actions/runs/5868047364 or
![Screenshot from 2023-08-15 16-35-27](https://github.com/nutanix/libvfio-user/assets/49617392/9d190714-311e-40cb-9977-0d4888d56d3f)
seems to work. I'm also a bit surprised how fast the arch job is.
