### PR TITLE
fix: incorrect number of dirty pages printed

### DIFF
--- a/lib/dma.c
+++ b/lib/dma.c
@@ -535,7 +535,7 @@ log_dirty_bitmap(vfu_ctx_t *vfu_ctx, dma_memory_region_t *region,
     size_t i;
     size_t count;
     for (i = 0, count = 0; i < size; i++) {
-        count += __builtin_popcount(bitmap[i]);
+        count += __builtin_popcount((uint8_t)bitmap[i]);
     }
     vfu_log(vfu_ctx, LOG_DEBUG, "dirty pages: get [%p, %p), %zu dirty pages",
             region->info.iova.iov_base, iov_end(&region->info.iova),


### PR DESCRIPTION
The `log_dirty_bitmap` function in `dma.c` would output the wrong number of dirty pages due to the `char` of the bitmap being sign-extended when implicitly being converted to `unsigned int` for `__builtin_popcount`. By adding an intermediate cast to `uint8_t` we avoid this incorrect behaviour.

See https://github.com/nutanix/libvfio-user/pull/746#discussion_r1297173318.