### PR TITLE
Introduce client object in python tests

### DIFF
--- a/test/py/libvfio_user.py
+++ b/test/py/libvfio_user.py
@@ -702,16 +702,12 @@ class Client:
         hdr = vfio_user_header(VFIO_USER_VERSION, size=len(payload))
         self.sock.send(hdr + payload)
         vfu_attach_ctx(ctx, expect=0)
-        fds, payload = get_reply_fds(self.sock, expect=0)
-        self.client_cmd_socket = socket.socket(fileno=fds[0]) if fds else None
+        payload = get_reply(self.sock, expect=0)
         return self.sock
 
     def disconnect(self, ctx):
         self.sock.close()
         self.sock = None
-        if self.client_cmd_socket is not None:
-            self.client_cmd_socket.close()
-            self.client_cmd_socket = None
 
         # notice client closed connection
         vfu_run_ctx(ctx, errno.ENOTCONN)

--- a/test/py/test_destroy.py
+++ b/test/py/test_destroy.py
@@ -35,10 +35,10 @@ ctx = None
 
 
 def setup_function(function):
-    global ctx, sock
+    global ctx, client
     ctx = prepare_ctx_for_dma()
     assert ctx is not None
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
 
 def teardown_function(function):

--- a/test/py/test_device_get_info.py
+++ b/test/py/test_device_get_info.py
@@ -49,11 +49,11 @@ def test_device_get_info():
 
     # test short write
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     payload = struct.pack("II", 0, 0)
 
-    msg(ctx, sock, VFIO_USER_DEVICE_GET_INFO, payload,
+    msg(ctx, client.sock, VFIO_USER_DEVICE_GET_INFO, payload,
         expect=errno.EINVAL)
 
     # bad argsz
@@ -61,7 +61,7 @@ def test_device_get_info():
     payload = vfio_user_device_info(argsz=8, flags=0,
                                     num_regions=0, num_irqs=0)
 
-    msg(ctx, sock, VFIO_USER_DEVICE_GET_INFO, payload,
+    msg(ctx, client.sock, VFIO_USER_DEVICE_GET_INFO, payload,
         expect=errno.EINVAL)
 
     # valid with larger argsz
@@ -69,7 +69,7 @@ def test_device_get_info():
     payload = vfio_user_device_info(argsz=32, flags=0,
                                     num_regions=0, num_irqs=0)
 
-    result = msg(ctx, sock, VFIO_USER_DEVICE_GET_INFO, payload)
+    result = msg(ctx, client.sock, VFIO_USER_DEVICE_GET_INFO, payload)
 
     (argsz, flags, num_regions, num_irqs) = struct.unpack("IIII", result)
 
@@ -78,7 +78,7 @@ def test_device_get_info():
     assert num_regions == VFU_PCI_DEV_NUM_REGIONS
     assert num_irqs == VFU_DEV_NUM_IRQS
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
     vfu_destroy_ctx(ctx)
 

--- a/test/py/test_device_get_region_info_zero_size.py
+++ b/test/py/test_device_get_region_info_zero_size.py
@@ -30,13 +30,13 @@
 from libvfio_user import *
 
 ctx = None
-sock = None
+client = None
 
 argsz = len(vfio_region_info())
 
 
 def test_device_get_region_info_setup():
-    global ctx, sock
+    global ctx, client
 
     ctx = vfu_create_ctx(flags=LIBVFIO_USER_FLAG_ATTACH_NB)
     assert ctx is not None
@@ -44,13 +44,13 @@ def test_device_get_region_info_setup():
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
 
 def test_device_get_region_info_zero_sized_region():
     """Tests that a zero-sized region has no caps."""
 
-    global sock
+    global client
 
     for index in [VFU_PCI_DEV_BAR1_REGION_IDX, VFU_PCI_DEV_MIGR_REGION_IDX]:
         payload = vfio_region_info(argsz=argsz, flags=0,
@@ -59,9 +59,9 @@ def test_device_get_region_info_zero_sized_region():
 
         hdr = vfio_user_header(VFIO_USER_DEVICE_GET_REGION_INFO,
                                size=len(payload))
-        sock.send(hdr + payload)
+        client.sock.send(hdr + payload)
         vfu_run_ctx(ctx)
-        result = get_reply(sock)
+        result = get_reply(client.sock)
 
         assert len(result) == argsz
 

--- a/test/py/test_irq_trigger.py
+++ b/test/py/test_irq_trigger.py
@@ -32,11 +32,11 @@ import ctypes as c
 import errno
 
 ctx = None
-sock = None
+client = None
 
 
 def test_irq_trigger_setup():
-    global ctx, sock
+    global ctx, client
 
     ctx = vfu_create_ctx(flags=LIBVFIO_USER_FLAG_ATTACH_NB)
     assert ctx is not None
@@ -50,7 +50,7 @@ def test_irq_trigger_setup():
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
 
 def test_irq_trigger_bad_subindex():
@@ -76,7 +76,7 @@ def test_irq_trigger():
 
     fd = eventfd(initval=4)
 
-    msg(ctx, sock, VFIO_USER_DEVICE_SET_IRQS, payload, fds=[fd])
+    msg(ctx, client.sock, VFIO_USER_DEVICE_SET_IRQS, payload, fds=[fd])
 
     vfu_irq_trigger(ctx, 8)
 

--- a/test/py/test_negotiate.py
+++ b/test/py/test_negotiate.py
@@ -161,15 +161,15 @@ def test_invalid_json_bad_pgsize2():
 
 
 def test_valid_negotiate_no_json():
-    sock = connect_sock()
+    client = Client(sock=connect_sock())
 
     payload = struct.pack("HH", LIBVFIO_USER_MAJOR, LIBVFIO_USER_MINOR)
     hdr = vfio_user_header(VFIO_USER_VERSION, size=len(payload))
-    sock.send(hdr + payload)
+    client.sock.send(hdr + payload)
 
     vfu_attach_ctx(ctx)
 
-    payload = get_reply(sock)
+    payload = get_reply(client.sock)
     (major, minor, json_str, _) = struct.unpack("HH%dsc" % (len(payload) - 5),
                                                 payload)
     assert major == LIBVFIO_USER_MAJOR
@@ -179,7 +179,7 @@ def test_valid_negotiate_no_json():
     assert json.capabilities.max_data_xfer_size == SERVER_MAX_DATA_XFER_SIZE
     # FIXME: migration object checks
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_valid_negotiate_empty_json():

--- a/test/py/test_pci_ext_caps.py
+++ b/test/py/test_pci_ext_caps.py
@@ -224,37 +224,37 @@ def test_find_ext_caps():
 
 
 def test_pci_ext_cap_write_hdr():
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     # struct pcie_ext_cap_hdr
     offset = cap_offsets[0]
     data = b'\x01'
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data, expect=errno.EPERM)
 
     # struct pcie_ext_cap_vsc_hdr also
     offset = cap_offsets[1] + 4
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data, expect=errno.EPERM)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_pci_ext_cap_readonly():
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     # start of vendor payload
     offset = cap_offsets[1] + 8
     data = b'\x01'
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data, expect=errno.EPERM)
 
     offset = cap_offsets[1] + 8
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
-                          count=5)
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
+                          offset=offset, count=5)
     assert payload == b'abcde'
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_pci_ext_cap_callback():
@@ -262,42 +262,42 @@ def test_pci_ext_cap_callback():
     # FIXME assignment to PCI config space from callback is ignored
     if is_32bit():
         return
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     # start of vendor payload
     offset = cap_offsets[2] + 8
     data = b"Hello world."
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
-                          count=len(data))
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
+                          offset=offset, count=len(data))
     assert payload == data
 
     data = b"Bye world."
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data)
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
-                          count=len(data))
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
+                          offset=offset, count=len(data))
     assert payload == data
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_pci_ext_cap_write_dsn():
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     data = struct.pack("II", 1, 2)
     offset = cap_offsets[0] + 4
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data, expect=errno.EPERM)
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
-                          count=len(data))
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
+                          offset=offset, count=len(data))
 
     # unchanged!
     assert payload == struct.pack("II", 4, 8)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_pci_ext_cap_write_vendor():
@@ -306,20 +306,20 @@ def test_pci_ext_cap_write_vendor():
     if is_32bit():
         return
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     data = struct.pack("II", 0x1, 0x2)
     # start of vendor payload
     offset = cap_offsets[2] + 8
-    write_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
+    write_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
                  count=len(data), data=data)
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=offset,
-                          count=len(data))
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
+                          offset=offset, count=len(data))
 
     assert payload == data
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_pci_ext_cap_cleanup():

--- a/test/py/test_setup_region.py
+++ b/test/py/test_setup_region.py
@@ -165,13 +165,13 @@ def test_setup_region_cfg_always_cb():
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX,
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
                           offset=0, count=2)
     assert payload == b'\xcc\xcc'
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_region_offset_overflow():
@@ -185,12 +185,12 @@ def test_region_offset_overflow():
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
-    read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX,
+    read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX,
                 offset=UINT64_MAX, count=256, expect=errno.EINVAL)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_access_region_zero_count():
@@ -203,40 +203,40 @@ def test_access_region_zero_count():
     ret = vfu_realize_ctx(ctx)
     assert ret == 0
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
-    payload = read_region(ctx, sock, VFU_PCI_DEV_BAR0_REGION_IDX, offset=0,
-                          count=0)
+    payload = read_region(ctx, client.sock, VFU_PCI_DEV_BAR0_REGION_IDX,
+                          offset=0, count=0)
     assert payload == b''
 
-    write_region(ctx, sock, VFU_PCI_DEV_BAR0_REGION_IDX, offset=0, count=0,
-                 data=payload)
+    write_region(ctx, client.sock, VFU_PCI_DEV_BAR0_REGION_IDX, offset=0,
+                 count=0, data=payload)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_access_region_large_count():
     global ctx
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
-    read_region(ctx, sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=0,
+    read_region(ctx, client.sock, VFU_PCI_DEV_CFG_REGION_IDX, offset=0,
                 count=SERVER_MAX_DATA_XFER_SIZE + 8, expect=errno.EINVAL)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_region_offset_too_short():
     global ctx
 
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
 
     payload = struct.pack("Q", 0)
 
-    msg(ctx, sock, VFIO_USER_REGION_WRITE, payload,
+    msg(ctx, client.sock, VFIO_USER_REGION_WRITE, payload,
         expect=errno.EINVAL)
 
-    disconnect_client(ctx, sock)
+    client.disconnect(ctx)
 
 
 def test_setup_region_cleanup():

--- a/test/py/test_shadow_ioeventfd.py
+++ b/test/py/test_shadow_ioeventfd.py
@@ -60,12 +60,12 @@ def test_shadow_ioeventfd():
     assert ret == 0
 
     # client queries I/O region FDs
-    sock = connect_client(ctx)
+    client = connect_client(ctx)
     payload = vfio_user_region_io_fds_request(
                 argsz=len(vfio_user_region_io_fds_reply()) +
                 len(vfio_user_sub_region_ioeventfd()), flags=0,
                 index=VFU_PCI_DEV_BAR0_REGION_IDX, count=0)
-    newfds, ret = msg_fds(ctx, sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS,
+    newfds, ret = msg_fds(ctx, client.sock, VFIO_USER_DEVICE_GET_REGION_IO_FDS,
                           payload, expect=0)
     reply, ret = vfio_user_region_io_fds_reply.pop_from_buffer(ret)
     assert reply.count == 1  # 1 eventfd


### PR DESCRIPTION
Thus far, the client end of the socket is the only piece of client state tracked in tests, for which a global `socket` variable has been used. In preparation to add more state, replace the `socket` global with a `client` global object that groups all client state.