### PR TITLE
make arch CI non-required

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -110,7 +110,6 @@ branches:
           - fedora-35
           - debian-11
           - debian-12
-          - arch-202307
       # Required. Enforce all configured restrictions for administrators. Set to true to enforce required status checks for repository administrators. Set to null to disable.
       enforce_admins: true
       # Required. Restrict who can push to this branch. Team and user restrictions are only available for organization-owned repositories. Set to null to disable.


### PR DESCRIPTION
The arch github action seems to not work at all. For now, just remove it
from the required checks; later, if there's no progress, we can remove
it altogether.

Signed-off-by: John Levon <john.levon@nutanix.com>
