### PR TITLE
docs: document SPDK dependency

### DIFF
--- a/docs/spdk.md
+++ b/docs/spdk.md
@@ -28,6 +28,8 @@ Use SPDK v23.05:
 	./configure --with-vfio-user
 	make
 
+Note that SPDK only works with the `spdk` branch of `libvfio-user` currently,
+due to live-migration-related changes in the library's `master` branch.
 
 Start SPDK:
 


### PR DESCRIPTION
We maintain an `spdk` branch for use by SPDK, until we have
implementation live migration v2 in both qemu and SPDK.

Signed-off-by: John Levon <john.levon@nutanix.com>
Change-Id: Ie27c4373dbac043395c2719858a4af7b4d77f37c
