### PR TITLE
docs: correct markdown links

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,7 @@ Live migration
 The `master` branch of `libvfio-user` implements live migration with a protocol
 based on vfio's v2 protocol. Currently, there is no support for this in any qemu
 client. For current use cases that support live migration, such as SPDK, you
-should refer to the [https://github.com/nutanix/libvfio-user/tree/migration-v1]
-(migration-v1 branch).
+should refer to the [migration-v1 branch](https://github.com/nutanix/libvfio-user/tree/migration-v1).
 
 qemu
 ----

--- a/docs/spdk.md
+++ b/docs/spdk.md
@@ -100,7 +100,7 @@ https://www.linux-kvm.org/page/Migration.
 
 Note that the above live migration code in `qemu` and `SPDK` relies on the older
 live migration format, this is kept in the
-[https://github.com/nutanix/libvfio-user/tree/migration-v1](migration-v1)
+[migration-v1](https://github.com/nutanix/libvfio-user/tree/migration-v1)
 branch of `libvfio-user`.
 
 libvirt


### PR DESCRIPTION
The syntax is [free text](https:/..).

Signed-off-by: John Levon <john.levon@nutanix.com>
