### PR TITLE
docs/qemu: add missing -numa argument

### DIFF
--- a/docs/qemu.md
+++ b/docs/qemu.md
@@ -69,6 +69,7 @@ $ imgpath=/path/to/bionic-server-cloudimg-amd64.img
 $ sudo ~/src/build/qemu-system-x86_64 \
    -machine accel=kvm,type=q35 -cpu host -m 2G \
    -mem-prealloc -object memory-backend-file,id=ram-node0,prealloc=yes,mem-path=/dev/hugepages/gpio,share=yes,size=2G \
+   -numa node,memdev=ram-node0 \
    -nographic \
    -device virtio-net-pci,netdev=net0 \
    -netdev user,id=net0,hostfwd=tcp::2222-:22 \


### PR DESCRIPTION
Add the missing argument to link the backing memory with the guest's
memory; this results in two separate 2G allocations - harmless in this
case, but would break usage for SPDK.

Signed-off-by: John Levon <john.levon@nutanix.com>
