### PR TITLE
lib/libvfio-user: Fix calloc-transposed-args reported by gcc >= 14

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -624,8 +624,7 @@ handle_device_get_region_io_fds(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
     msg->out.nr_fds = 0;
 
     if (max_sent_sub_regions > 0 && req->argsz >= reply->argsz) {
-        msg->out.fds = calloc(sizeof(int),
-                              max_sent_sub_regions + nr_shadow_reg);
+        msg->out.fds = calloc(max_sent_sub_regions + nr_shadow_reg, sizeof(int));
         if (msg->out.fds == NULL) {
             return -1;
         }


### PR DESCRIPTION
Fixes #801.

Signed-off-by: Michal Berger <michal.berger@intel.com>