### PR TITLE
workaround centos:7 issue

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,11 +1,12 @@
 name: pull_request
 on: pull_request
+
 jobs:
   ubuntu-20:
     timeout-minutes: 10
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: pre-push
         run: |
           sudo apt-get update
@@ -17,7 +18,7 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: pre-push
         run: |
           sudo apt-get update
@@ -30,9 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     container: centos:7
     steps:
-      - uses: actions/checkout@v3
       - name: pre-push
         run: |
+          # Sigh.
+          sed -i s/mirror.centos.org/vault.centos.org/g /etc/yum.repos.d/*.repo
+          sed -i s/^#.*baseurl=http/baseurl=http/g /etc/yum.repos.d/*.repo
+          sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
+          # Avoid https://github.com/actions/checkout/issues/1590
+          curl -L -o libvfio-user.tar.gz https://github.com/${GITHUB_REPOSITORY}/archive/${GITHUB_SHA}.tar.gz
+          tar xvf libvfio-user.tar.gz
+          cd libvfio-user-${GITHUB_SHA}
           # NB: no working flake8
           yum -y install make gcc-4.8.5 epel-release pciutils
           yum -y install clang clang-analyzer json-c-devel libcmocka-devel \
@@ -43,7 +51,7 @@ jobs:
     runs-on: ubuntu-latest
     container: fedora:35
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: pre-push
         run: |
           dnf -y install --releasever=35 \
@@ -56,7 +64,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: debian:11
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: pre-push
         run: |
           apt-get update
@@ -69,7 +77,7 @@ jobs:
     runs-on: ubuntu-22.04
     container: debian:12
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: pre-push
         run: |
           apt-get update
@@ -81,6 +89,6 @@ jobs:
     runs-on: ubuntu-latest
     container: vlajos/misspell-fixer
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: run misspell-fixer
         run: /misspell-fixer/misspell-fixer -sv .


### PR DESCRIPTION
The centos:7 build no longer works on github due to this:

Run actions/checkout@v3
/usr/bin/docker exec  02e2cf2da72963d76b12a421e48bc0790138ee97bf567c8afcdf792dbc2093d8 sh -c "cat /etc/*release | grep ^ID"
/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `CXXABI_1.3.9' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.21' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.25' not found (required by /__e/node20/bin/node)

See https://github.com/actions/checkout/issues/1590

The workaround suggested there does not work, at least for centos:7.

Instead, we'll open-code the checkout operation instead of using the
github action.

For the other jobs, which still work for now, move to the non-deprecated
checkout@v4.

Signed-off-by: John Levon <john.levon@nutanix.com>