### PR TITLE
samples: keep coverity quiet

### DIFF
--- a/samples/client.c
+++ b/samples/client.c
@@ -821,7 +821,8 @@ get_dirty_bitmap(int sock, struct client_dma_region *dma_region,
     uint64_t bitmap_size = get_bitmap_size(dma_region->map.size,
                                            sysconf(_SC_PAGESIZE));
 
-    size_t size = sizeof(*res) + sizeof(*report) + bitmap_size;
+    /* Saturating add to keep coverity happy. */
+    size_t size = satadd_u64(sizeof(*res) + sizeof(*report), bitmap_size);
 
     void *data = calloc(1, size);
     assert(data != NULL);


### PR DESCRIPTION
>>>     CID 467268:    (INTEGER_OVERFLOW)
>>>     Expression "32UL + bitmap_size", which is equal to 31, where
"bitmap_size" is known to be equal to 18446744073709551615, overflows
the type that receives it, an unsigned integer 64 bits wide.
824         size_t size = sizeof(*res) + sizeof(*report) + bitmap_size;

It's correct, this could overflow, though as this is example code, it
doesn't matter. Nonetheless let's make this be a saturating add.

Signed-off-by: John Levon <john.levon@nutanix.com>
