### PR TITLE
Update runs-on past ubuntu-20.04

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -105,7 +105,6 @@ branches:
         # Required. The list of status checks to require in order to merge into this branch
         contexts:
           - centos-7
-          - ubuntu-20
           - ubuntu-22
           - fedora-35
           - debian-11

--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   coverity:
     timeout-minutes: 5
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - name: run-scan

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -2,18 +2,6 @@ name: pull_request
 on: pull_request
 
 jobs:
-  ubuntu-20:
-    timeout-minutes: 10
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-      - name: pre-push
-        run: |
-          sudo apt-get update
-          sudo apt-get -y install libjson-c-dev libcmocka-dev clang \
-            clang-tools valgrind python3-pytest debianutils flake8 meson \
-            ninja-build
-          ./.github/workflows/pull_request.sh
   ubuntu-22:
     timeout-minutes: 10
     runs-on: ubuntu-22.04
@@ -61,7 +49,7 @@ jobs:
           ./.github/workflows/pull_request.sh
   debian-11:
     timeout-minutes: 10
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     container: debian:11
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
It seems github have removed all ubuntu-20.04 runners, so these jobs
were waiting forever.

Signed-off-by: John Levon <john.levon@nutanix.com>
