### PR TITLE
Add support for IOMMUFD IOCTLs

### DIFF
--- a/include/vfio-user.h
+++ b/include/vfio-user.h
@@ -52,6 +52,13 @@ extern "C" {
 
 #define VFIO_USER_DEFAULT_MAX_DATA_XFER_SIZE (1024 * 1024)
 
+/*
+ * vfio-user protocol commands
+ *
+ * Commands 1-18 are part of the base protocol. Commands 19+ implement
+ * optional protocol extensions that must be negotiated via capabilities
+ * during VFIO_USER_VERSION exchange.
+ */
 enum vfio_user_command {
     VFIO_USER_VERSION                   = 1,
     VFIO_USER_DMA_MAP                   = 2,
@@ -70,6 +77,22 @@ enum vfio_user_command {
     VFIO_USER_DEVICE_FEATURE            = 16,
     VFIO_USER_MIG_DATA_READ             = 17,
     VFIO_USER_MIG_DATA_WRITE            = 18,
+    /*
+     * iommufd protocol extension
+     *
+     * These commands require negotiating "iommufd": {"supported": true}
+     * capability during VFIO_USER_VERSION. They provide an alternative to
+     * the legacy VFIO_USER_DMA_MAP/UNMAP commands, mirroring the Linux
+     * kernel's iommufd API.
+     */
+    VFIO_USER_IOMMUFD_ALLOC_IOAS        = 19,
+    VFIO_USER_IOMMUFD_DESTROY_IOAS      = 20,
+    VFIO_USER_IOMMUFD_IOAS_MAP          = 21,
+    VFIO_USER_IOMMUFD_IOAS_UNMAP        = 22,
+    VFIO_USER_IOMMUFD_IOAS_COPY         = 23,
+    VFIO_USER_IOMMUFD_BIND              = 24,
+    VFIO_USER_IOMMUFD_ATTACH_PT         = 25,
+    VFIO_USER_IOMMUFD_DETACH_PT         = 26,
     VFIO_USER_MAX,
 };
 
@@ -142,6 +165,90 @@ struct vfio_user_dma_unmap {
     uint64_t size;
     struct vfio_user_bitmap bitmap[];
 };
+
+/*
+ * iommufd protocol structures
+ * These are used when VFIO_USER_CAP_IOMMUFD is negotiated
+ */
+
+/* VFIO_USER_IOMMUFD_ALLOC_IOAS */
+struct vfio_user_iommufd_alloc_ioas {
+    uint32_t argsz;
+    uint32_t flags;
+    uint32_t out_ioas_id;  /* Server allocates and returns IOAS ID */
+    uint32_t __reserved;
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_DESTROY_IOAS */
+struct vfio_user_iommufd_destroy_ioas {
+    uint32_t argsz;
+    uint32_t flags;
+    uint32_t ioas_id;
+    uint32_t __reserved;
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_IOAS_MAP */
+struct vfio_user_iommufd_ioas_map {
+    uint32_t argsz;
+    uint32_t flags;
+#define VFIO_USER_IOMMUFD_MAP_WRITEABLE     (1 << 0)
+#define VFIO_USER_IOMMUFD_MAP_READABLE      (1 << 1)
+    uint32_t ioas_id;      /* Target IOAS */
+    uint32_t __reserved;
+    uint64_t user_va;      /* Userspace virtual address (for tracking) */
+    uint64_t length;
+    uint64_t iova;         /* Output: server-allocated IOVA */
+    uint64_t offset;       /* Offset in passed fd */
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_IOAS_UNMAP */
+struct vfio_user_iommufd_ioas_unmap {
+    uint32_t argsz;
+    uint32_t flags;
+#define VFIO_USER_IOMMUFD_UNMAP_ALL  (1 << 0)
+    uint32_t ioas_id;
+    uint32_t __reserved;
+    uint64_t iova;
+    uint64_t length;
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_IOAS_COPY */
+struct vfio_user_iommufd_ioas_copy {
+    uint32_t argsz;
+    uint32_t flags;
+    uint32_t src_ioas_id;
+    uint32_t dst_ioas_id;
+    uint64_t src_iova;
+    uint64_t dst_iova;
+    uint64_t length;
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_BIND */
+struct vfio_user_iommufd_bind {
+    uint32_t argsz;
+    uint32_t flags;
+    int32_t  iommufd;      /* Server's iommufd fd (opaque to client) */
+    uint32_t out_devid;    /* Server returns devid */
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_ATTACH_PT */
+struct vfio_user_iommufd_attach_pt {
+    uint32_t argsz;
+    uint32_t flags;
+#define VFIO_USER_IOMMUFD_ATTACH_PASID  (1 << 0)
+    uint32_t pt_id;        /* Input: IOAS or HWPT id
+                            * Output: attached HWPT id */
+    uint32_t pasid;        /* For devices with PASID support */
+} __attribute__((packed));
+
+/* VFIO_USER_IOMMUFD_DETACH_PT */
+struct vfio_user_iommufd_detach_pt {
+    uint32_t argsz;
+    uint32_t flags;
+#define VFIO_USER_IOMMUFD_DETACH_PASID  (1 << 0)
+    uint32_t pasid;
+    uint32_t __reserved;
+} __attribute__((packed));
 
 struct vfio_user_region_access {
     uint64_t    offset;

--- a/lib/iommufd.c
+++ b/lib/iommufd.c
@@ -1,0 +1,494 @@
+/*
+ * Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+ *
+ * Authors: Ben Walker <ben@nvidia.com>
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *        notice, this list of conditions and the following disclaimer in the
+ *        documentation and/or other materials provided with the distribution.
+ *      * Neither the name of NVIDIA nor the names of its contributors may be
+ *        used to endorse or promote products derived from this software without
+ *        specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ *  DAMAGE.
+ *
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include "common.h"
+#include "iommufd.h"
+#include "libvfio-user.h"
+#include "private.h"
+
+iommufd_controller_t *
+iommufd_controller_create(struct vfu_ctx *vfu_ctx)
+{
+    iommufd_controller_t *iommufd;
+
+    assert(vfu_ctx != NULL);
+
+    iommufd = calloc(1, sizeof(*iommufd));
+    if (iommufd == NULL) {
+        return NULL;
+    }
+
+    iommufd->vfu_ctx = vfu_ctx;
+    iommufd->enabled = false;
+    iommufd->device_bound = false;
+    iommufd->bound_ioas_id = 0;
+    iommufd->next_ioas_id = 1; /* Start IOAS IDs at 1 */
+    TAILQ_INIT(&iommufd->ioas_list);
+
+    return iommufd;
+}
+
+static void
+iommufd_free_mapping(iommufd_mapping_t *mapping)
+{
+    if (mapping == NULL) {
+        return;
+    }
+
+    if (mapping->vaddr != NULL && mapping->vaddr != MAP_FAILED) {
+        munmap(mapping->vaddr, mapping->length);
+    }
+
+    if (mapping->fd >= 0) {
+        close(mapping->fd);
+    }
+
+    free(mapping);
+}
+
+static void
+iommufd_free_ioas(iommufd_ioas_t *ioas)
+{
+    iommufd_mapping_t *mapping;
+
+    if (ioas == NULL) {
+        return;
+    }
+
+    while (!TAILQ_EMPTY(&ioas->mappings)) {
+        mapping = TAILQ_FIRST(&ioas->mappings);
+        TAILQ_REMOVE(&ioas->mappings, mapping, link);
+        iommufd_free_mapping(mapping);
+    }
+
+    free(ioas);
+}
+
+void
+iommufd_controller_destroy(iommufd_controller_t *iommufd)
+{
+    iommufd_ioas_t *ioas;
+
+    if (iommufd == NULL) {
+        return;
+    }
+
+    while (!TAILQ_EMPTY(&iommufd->ioas_list)) {
+        ioas = TAILQ_FIRST(&iommufd->ioas_list);
+        TAILQ_REMOVE(&iommufd->ioas_list, ioas, link);
+        iommufd_free_ioas(ioas);
+    }
+
+    free(iommufd);
+}
+
+static iommufd_ioas_t *
+iommufd_find_ioas(iommufd_controller_t *iommufd, uint32_t ioas_id)
+{
+    iommufd_ioas_t *ioas;
+
+    TAILQ_FOREACH(ioas, &iommufd->ioas_list, link) {
+        if (ioas->ioas_id == ioas_id) {
+            return ioas;
+        }
+    }
+
+    return NULL;
+}
+
+/*
+ * Find an iommufd mapping by IOVA.
+ * Returns the mapping if found, NULL otherwise.
+ * Optimized with thread-local hint (similar to DMA controller's region_hint).
+ */
+iommufd_mapping_t *
+iommufd_find_mapping(iommufd_controller_t *iommufd, uint64_t iova, size_t len)
+{
+    static __thread iommufd_mapping_t *mapping_hint;
+    iommufd_ioas_t *ioas;
+    iommufd_mapping_t *mapping;
+
+    if (iommufd == NULL || !iommufd->enabled) {
+        return NULL;
+    }
+
+    /* Fast path: check hint first (similar to DMA controller's region_hint) */
+    if (mapping_hint != NULL) {
+        /* Check if hint matches the requested IOVA range */
+        if (iova >= mapping_hint->iova &&
+            iova + len <= mapping_hint->iova + mapping_hint->length) {
+            return mapping_hint;
+        }
+        /* Hint doesn't match, clear it and continue to search */
+        mapping_hint = NULL;
+    }
+
+    /* Fast path: check the bound IOAS first (where most mappings are) */
+    if (iommufd->device_bound && iommufd->bound_ioas_id != 0) {
+        ioas = iommufd_find_ioas(iommufd, iommufd->bound_ioas_id);
+        if (ioas != NULL) {
+            TAILQ_FOREACH(mapping, &ioas->mappings, link) {
+                /* Check if the requested IOVA range overlaps with this mapping */
+                if (iova >= mapping->iova && iova + len <= mapping->iova + mapping->length) {
+                    mapping_hint = mapping; /* Update hint for next time */
+                    return mapping;
+                }
+            }
+        }
+    }
+
+    /* Slow path: search through other IOAS structures */
+    TAILQ_FOREACH(ioas, &iommufd->ioas_list, link) {
+        /* Skip the bound IOAS since we already checked it */
+        if (iommufd->device_bound && ioas->ioas_id == iommufd->bound_ioas_id) {
+            continue;
+        }
+
+        TAILQ_FOREACH(mapping, &ioas->mappings, link) {
+            /* Check if the requested IOVA range overlaps with this mapping */
+            if (iova >= mapping->iova && iova + len <= mapping->iova + mapping->length) {
+                mapping_hint = mapping; /* Update hint for next time */
+                return mapping;
+            }
+        }
+    }
+
+    return NULL;
+}
+
+int
+iommufd_alloc_ioas(iommufd_controller_t *iommufd, uint32_t *ioas_id)
+{
+    iommufd_ioas_t *ioas;
+
+    assert(iommufd != NULL);
+    assert(ioas_id != NULL);
+
+    if (!iommufd->enabled) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    ioas = calloc(1, sizeof(*ioas));
+    if (ioas == NULL) {
+        return ERROR_INT(ENOMEM);
+    }
+
+    ioas->ioas_id = iommufd->next_ioas_id++;
+    TAILQ_INIT(&ioas->mappings);
+    TAILQ_INSERT_TAIL(&iommufd->ioas_list, ioas, link);
+
+    *ioas_id = ioas->ioas_id;
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG, "allocated IOAS id=%u", *ioas_id);
+
+    return 0;
+}
+
+int
+iommufd_destroy_ioas(iommufd_controller_t *iommufd, uint32_t ioas_id)
+{
+    iommufd_ioas_t *ioas;
+
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        return ERROR_INT(EINVAL);
+    }
+
+    ioas = iommufd_find_ioas(iommufd, ioas_id);
+    if (ioas == NULL) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "IOAS id=%u not found", ioas_id);
+        return ERROR_INT(ENOENT);
+    }
+
+    /* Cannot destroy IOAS that is currently attached */
+    if (iommufd->device_bound && iommufd->bound_ioas_id == ioas_id) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "cannot destroy attached IOAS id=%u",
+                ioas_id);
+        return ERROR_INT(EBUSY);
+    }
+
+    TAILQ_REMOVE(&iommufd->ioas_list, ioas, link);
+    iommufd_free_ioas(ioas);
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG, "destroyed IOAS id=%u", ioas_id);
+
+    return 0;
+}
+
+int
+iommufd_bind_device(iommufd_controller_t *iommufd)
+{
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        return ERROR_INT(EINVAL);
+    }
+
+    if (iommufd->device_bound) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "device already bound");
+        return ERROR_INT(EEXIST);
+    }
+
+    iommufd->device_bound = true;
+    iommufd->bound_ioas_id = 0;
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG, "device bound to iommufd");
+
+    return 0;
+}
+
+int
+iommufd_attach_ioas(iommufd_controller_t *iommufd, uint32_t ioas_id)
+{
+    iommufd_ioas_t *ioas;
+
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        return ERROR_INT(EINVAL);
+    }
+
+    if (!iommufd->device_bound) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "device not bound");
+        return ERROR_INT(EINVAL);
+    }
+
+    ioas = iommufd_find_ioas(iommufd, ioas_id);
+    if (ioas == NULL) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "IOAS id=%u not found", ioas_id);
+        return ERROR_INT(ENOENT);
+    }
+
+    iommufd->bound_ioas_id = ioas_id;
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG, "device attached to IOAS id=%u", ioas_id);
+
+    return 0;
+}
+
+int
+iommufd_detach_ioas(iommufd_controller_t *iommufd)
+{
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        return ERROR_INT(EINVAL);
+    }
+
+    if (!iommufd->device_bound) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "device not bound");
+        return ERROR_INT(EINVAL);
+    }
+
+    if (iommufd->bound_ioas_id == 0) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "device not attached to any IOAS");
+        return ERROR_INT(EINVAL);
+    }
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG, "device detached from IOAS id=%u",
+            iommufd->bound_ioas_id);
+
+    iommufd->bound_ioas_id = 0;
+
+    return 0;
+}
+
+uint64_t
+iommufd_map_iova(iommufd_controller_t *iommufd, uint32_t ioas_id,
+                 uint64_t user_va, uint64_t length, uint64_t offset,
+                 uint32_t flags, int fd)
+{
+    iommufd_ioas_t *ioas;
+    iommufd_mapping_t *mapping;
+    void *vaddr;
+    uint32_t prot = 0;
+    size_t page_size;
+
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        errno = EINVAL;
+        return 0;
+    }
+
+    ioas = iommufd_find_ioas(iommufd, ioas_id);
+    if (ioas == NULL) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "IOAS id=%u not found", ioas_id);
+        errno = ENOENT;
+        return 0;
+    }
+
+    /* Determine page size and round mmap parameters */
+    page_size = getpagesize();
+    off_t mmap_offset = (offset / page_size) * page_size;
+    size_t offset_in_page = offset - mmap_offset;
+    size_t mmap_length = length + offset_in_page;
+    mmap_length = ((mmap_length + page_size - 1) / page_size) * page_size;
+
+    /* Convert flags to prot */
+    if (flags & VFIO_USER_IOMMUFD_MAP_READABLE) {
+        prot |= PROT_READ;
+    }
+    if (flags & VFIO_USER_IOMMUFD_MAP_WRITEABLE) {
+        prot |= PROT_WRITE;
+    }
+
+    /* mmap the memory */
+    vaddr = mmap(NULL, mmap_length, prot, MAP_SHARED, fd, mmap_offset);
+    if (vaddr == MAP_FAILED) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR,
+                "failed to mmap fd=%d offset=%#llx length=%#zx: %m",
+                fd, (unsigned long long)mmap_offset, mmap_length);
+        errno = ENOMEM;
+        return 0;
+    }
+
+    /* Allocate mapping structure */
+    mapping = calloc(1, sizeof(*mapping));
+    if (mapping == NULL) {
+        munmap(vaddr, mmap_length);
+        errno = ENOMEM;
+        return 0;
+    }
+
+    /* The IOVA is the server's vaddr (offset-adjusted) */
+    mapping->vaddr = vaddr;
+    mapping->iova = (uint64_t)(uintptr_t)(vaddr + offset_in_page);
+    mapping->length = length;
+    mapping->user_va = user_va;
+    mapping->offset = offset;
+    mapping->fd = fd;
+    mapping->flags = flags;
+
+    TAILQ_INSERT_TAIL(&ioas->mappings, mapping, link);
+
+    vfu_log(iommufd->vfu_ctx, LOG_DEBUG,
+            "mapped IOAS id=%u: iova=%#llx length=%#llx user_va=%#llx",
+            ioas_id, (unsigned long long)mapping->iova,
+            (unsigned long long)length, (unsigned long long)user_va);
+
+    /* Call the dma_register callback if set */
+    if (iommufd->vfu_ctx->dma_register != NULL) {
+        vfu_dma_info_t info = {
+            .iova.iov_base = (void *)(uintptr_t)mapping->iova,
+            .iova.iov_len = mapping->length,
+            .vaddr = vaddr + offset_in_page,
+            .mapping.iov_base = vaddr,
+            .mapping.iov_len = mmap_length,
+            .page_size = page_size,
+            .prot = prot
+        };
+        iommufd->vfu_ctx->in_cb = CB_DMA_REGISTER;
+        iommufd->vfu_ctx->dma_register(iommufd->vfu_ctx, &info);
+        iommufd->vfu_ctx->in_cb = CB_NONE;
+    }
+
+    return mapping->iova;
+}
+
+int
+iommufd_unmap_iova(iommufd_controller_t *iommufd, uint32_t ioas_id,
+                   uint64_t iova, uint64_t length)
+{
+    iommufd_ioas_t *ioas;
+    iommufd_mapping_t *mapping;
+
+    assert(iommufd != NULL);
+
+    if (!iommufd->enabled) {
+        return ERROR_INT(EINVAL);
+    }
+
+    ioas = iommufd_find_ioas(iommufd, ioas_id);
+    if (ioas == NULL) {
+        vfu_log(iommufd->vfu_ctx, LOG_ERR, "IOAS id=%u not found", ioas_id);
+        return ERROR_INT(ENOENT);
+    }
+
+    TAILQ_FOREACH(mapping, &ioas->mappings, link) {
+        if (mapping->iova == iova && mapping->length == length) {
+            /* Call dma_unregister callback if set */
+            if (iommufd->vfu_ctx->dma_unregister != NULL) {
+                vfu_dma_info_t info = {
+                    .iova.iov_base = (void *)(uintptr_t)mapping->iova,
+                    .iova.iov_len = mapping->length,
+                    .vaddr = (void *)(uintptr_t)mapping->iova,
+                    .mapping.iov_base = mapping->vaddr,
+                    .mapping.iov_len = mapping->length,
+                    .page_size = getpagesize(),
+                    .prot = 0
+                };
+                iommufd->vfu_ctx->in_cb = CB_DMA_UNREGISTER;
+                iommufd->vfu_ctx->dma_unregister(iommufd->vfu_ctx, &info);
+                iommufd->vfu_ctx->in_cb = CB_NONE;
+            }
+
+            TAILQ_REMOVE(&ioas->mappings, mapping, link);
+            iommufd_free_mapping(mapping);
+
+            vfu_log(iommufd->vfu_ctx, LOG_DEBUG,
+                    "unmapped IOAS id=%u: iova=%#llx length=%#llx",
+                    ioas_id, (unsigned long long)iova, (unsigned long long)length);
+
+            return 0;
+        }
+    }
+
+    vfu_log(iommufd->vfu_ctx, LOG_ERR,
+            "mapping not found in IOAS id=%u: iova=%#llx length=%#llx",
+            ioas_id, (unsigned long long)iova, (unsigned long long)length);
+
+    return ERROR_INT(ENOENT);
+}
+
+void
+iommufd_enable(iommufd_controller_t *iommufd)
+{
+    assert(iommufd != NULL);
+    iommufd->enabled = true;
+    vfu_log(iommufd->vfu_ctx, LOG_INFO, "iommufd mode enabled");
+}
+
+bool
+iommufd_is_enabled(iommufd_controller_t *iommufd)
+{
+    return iommufd != NULL && iommufd->enabled;
+}
+
+/* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/lib/iommufd.h
+++ b/lib/iommufd.h
@@ -1,0 +1,162 @@
+/*
+ * Copyright (c) 2026 NVIDIA Corporation. All rights reserved.
+ *
+ * Authors: Ben Walker <ben@nvidia.com>
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above copyright
+ *        notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *        notice, this list of conditions and the following disclaimer in the
+ *        documentation and/or other materials provided with the distribution.
+ *      * Neither the name of NVIDIA nor the names of its contributors may be
+ *        used to endorse or promote products derived from this software without
+ *        specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ *  SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ *  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+ *  DAMAGE.
+ *
+ */
+
+/*
+ * iommufd support for libvfio-user
+ */
+
+#ifndef LIB_VFIO_USER_IOMMUFD_H
+#define LIB_VFIO_USER_IOMMUFD_H
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <sys/queue.h>
+
+struct vfu_ctx;
+
+/*
+ * Represents a single IOVA mapping within an IOAS.
+ * The IOVA is assigned to be equal to the server's vaddr.
+ */
+typedef struct iommufd_mapping {
+    uint64_t            iova;           /* Server's vaddr, used as IOVA */
+    uint64_t            length;
+    uint64_t            user_va;        /* Client's vaddr (for tracking) */
+    uint64_t            offset;         /* Offset in fd */
+    int                 fd;
+    uint32_t            flags;
+    void                *vaddr;         /* Server's mapped address */
+    TAILQ_ENTRY(iommufd_mapping) link;
+} iommufd_mapping_t;
+
+/*
+ * Represents an IOAS (I/O Address Space).
+ */
+typedef struct iommufd_ioas {
+    uint32_t            ioas_id;
+    TAILQ_HEAD(, iommufd_mapping) mappings;
+    TAILQ_ENTRY(iommufd_ioas) link;
+} iommufd_ioas_t;
+
+/*
+ * iommufd controller state.
+ * Stored per connection (in vfu_ctx), reset on client disconnect.
+ */
+typedef struct iommufd_controller {
+    struct vfu_ctx      *vfu_ctx;
+    bool                enabled;        /* iommufd mode negotiated */
+    bool                device_bound;   /* Device bound to iommufd */
+    uint32_t            bound_ioas_id;  /* Currently attached IOAS */
+    uint32_t            next_ioas_id;   /* For allocating new IOAS IDs */
+    TAILQ_HEAD(, iommufd_ioas) ioas_list;
+} iommufd_controller_t;
+
+/*
+ * Create a new iommufd controller.
+ */
+iommufd_controller_t *
+iommufd_controller_create(struct vfu_ctx *vfu_ctx);
+
+/*
+ * Destroy an iommufd controller and free all resources.
+ */
+void
+iommufd_controller_destroy(iommufd_controller_t *iommufd);
+
+/*
+ * Allocate a new IOAS.
+ * Returns the new IOAS ID on success, or -1 with errno set on failure.
+ */
+int
+iommufd_alloc_ioas(iommufd_controller_t *iommufd, uint32_t *ioas_id);
+
+/*
+ * Destroy an IOAS and all its mappings.
+ */
+int
+iommufd_destroy_ioas(iommufd_controller_t *iommufd, uint32_t ioas_id);
+
+/*
+ * Bind the device to iommufd.
+ */
+int
+iommufd_bind_device(iommufd_controller_t *iommufd);
+
+/*
+ * Attach device to an IOAS (page table).
+ */
+int
+iommufd_attach_ioas(iommufd_controller_t *iommufd, uint32_t ioas_id);
+
+/*
+ * Detach device from its current IOAS.
+ */
+int
+iommufd_detach_ioas(iommufd_controller_t *iommufd);
+
+/*
+ * Map memory into an IOAS.
+ * The server mmaps the fd and uses the resulting vaddr as the IOVA.
+ * Returns the allocated IOVA on success, or 0 on failure with errno set.
+ */
+uint64_t
+iommufd_map_iova(iommufd_controller_t *iommufd, uint32_t ioas_id,
+                 uint64_t user_va, uint64_t length, uint64_t offset,
+                 uint32_t flags, int fd);
+
+/*
+ * Unmap memory from an IOAS.
+ */
+int
+iommufd_unmap_iova(iommufd_controller_t *iommufd, uint32_t ioas_id,
+                   uint64_t iova, uint64_t length);
+
+/*
+ * Enable iommufd mode after successful capability negotiation.
+ */
+void
+iommufd_enable(iommufd_controller_t *iommufd);
+
+/*
+ * Check if iommufd mode is enabled.
+ */
+bool
+iommufd_is_enabled(iommufd_controller_t *iommufd);
+
+/*
+ * Find an iommufd mapping by IOVA.
+ * Returns the mapping if found, NULL otherwise.
+ */
+iommufd_mapping_t *
+iommufd_find_mapping(iommufd_controller_t *iommufd, uint64_t iova, size_t len);
+
+#endif /* LIB_VFIO_USER_IOMMUFD_H */
+
+/* ex: set tabstop=4 shiftwidth=4 softtabstop=4 expandtab: */

--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -48,9 +48,11 @@
 #include <sys/socket.h>
 #include <sys/stat.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <sys/eventfd.h>
 
 #include "dma.h"
+#include "iommufd.h"
 #include "irq.h"
 #include "libvfio-user.h"
 #include "migration.h"
@@ -61,6 +63,15 @@
 
 static int
 vfu_reset_ctx(vfu_ctx_t *vfu_ctx, int reason);
+
+/* iommufd command handlers */
+static int handle_iommufd_alloc_ioas(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_destroy_ioas(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_bind(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_attach_pt(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_detach_pt(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_ioas_map(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
+static int handle_iommufd_ioas_unmap(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg);
 
 EXPORT void
 vfu_log(vfu_ctx_t *vfu_ctx, int level, const char *fmt, ...)
@@ -1378,6 +1389,34 @@ handle_request(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
         ret = handle_mig_data_write(vfu_ctx, msg);
         break;
 
+    case VFIO_USER_IOMMUFD_ALLOC_IOAS:
+        ret = handle_iommufd_alloc_ioas(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_DESTROY_IOAS:
+        ret = handle_iommufd_destroy_ioas(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_BIND:
+        ret = handle_iommufd_bind(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_ATTACH_PT:
+        ret = handle_iommufd_attach_pt(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_DETACH_PT:
+        ret = handle_iommufd_detach_pt(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_IOAS_MAP:
+        ret = handle_iommufd_ioas_map(vfu_ctx, msg);
+        break;
+
+    case VFIO_USER_IOMMUFD_IOAS_UNMAP:
+        ret = handle_iommufd_ioas_unmap(vfu_ctx, msg);
+        break;
+
     default:
         msg->processed_cmd = false;
         vfu_log(vfu_ctx, LOG_ERR, "bad command %d", msg->hdr.cmd);
@@ -1861,6 +1900,9 @@ vfu_destroy_ctx(vfu_ctx_t *vfu_ctx)
     if (vfu_ctx->dma != NULL) {
         dma_controller_destroy(vfu_ctx->dma);
     }
+    if (vfu_ctx->iommufd != NULL) {
+        iommufd_controller_destroy(vfu_ctx->iommufd);
+    }
     free_sparse_mmap_areas(vfu_ctx);
     free_regions(vfu_ctx);
     free(vfu_ctx->migration);
@@ -1955,6 +1997,12 @@ vfu_create_ctx(vfu_trans_t trans, const char *path, int flags, void *pvt,
         if (err < 0) {
             goto err_out;
         }
+    }
+
+    /* Create iommufd controller */
+    vfu_ctx->iommufd = iommufd_controller_create(vfu_ctx);
+    if (vfu_ctx->iommufd == NULL) {
+        goto err_out;
     }
 
     return vfu_ctx;
@@ -2215,6 +2263,8 @@ EXPORT int
 vfu_addr_to_sgl(vfu_ctx_t *vfu_ctx, vfu_dma_addr_t dma_addr,
                 size_t len, dma_sg_t *sgl, size_t max_nr_sgs, int prot)
 {
+    iommufd_mapping_t *mapping;
+
 #ifdef DEBUG
     assert(vfu_ctx != NULL);
 
@@ -2225,6 +2275,29 @@ vfu_addr_to_sgl(vfu_ctx_t *vfu_ctx, vfu_dma_addr_t dma_addr,
     quiesce_check_allowed(vfu_ctx, __func__);
 #endif
 
+    /* Check iommufd mappings first if iommufd is enabled */
+    if (vfu_ctx->iommufd != NULL && iommufd_is_enabled(vfu_ctx->iommufd)) {
+        /* Validate that the IOVA is registered (for security) */
+        mapping = iommufd_find_mapping(vfu_ctx->iommufd, (uint64_t)(uintptr_t)dma_addr, len);
+        if (mapping != NULL) {
+            /* Found in iommufd - create SGL entry with special region index */
+            if (max_nr_sgs < 1) {
+                return ERROR_INT(ERANGE) - 1; /* Need at least 1 SG entry */
+            }
+
+            /* Use INT_MAX as special region index to mark iommufd mapping */
+            /* In iommufd mode, IOVA equals the server's virtual address, so we can use it directly */
+            sgl[0].dma_addr = dma_addr;
+            sgl[0].region = INT_MAX;
+            sgl[0].length = len;
+            sgl[0].offset = 0; /* Not used in iommufd mode since IOVA = vaddr */
+            sgl[0].writeable = (prot & PROT_WRITE) != 0;
+
+            return 1;
+        }
+    }
+
+    /* Fall back to legacy DMA controller */
     return dma_addr_to_sgl(vfu_ctx->dma, dma_addr, len, sgl, max_nr_sgs, prot);
 }
 
@@ -2232,6 +2305,9 @@ EXPORT int
 vfu_sgl_get(vfu_ctx_t *vfu_ctx, dma_sg_t *sgl, struct iovec *iov, size_t cnt,
             int flags UNUSED)
 {
+    dma_sg_t *sg;
+    size_t i;
+
 #ifdef DEBUG
     if (unlikely(vfu_ctx->dma_unregister == NULL) || flags != 0) {
         return ERROR_INT(EINVAL);
@@ -2240,7 +2316,35 @@ vfu_sgl_get(vfu_ctx_t *vfu_ctx, dma_sg_t *sgl, struct iovec *iov, size_t cnt,
     quiesce_check_allowed(vfu_ctx, __func__);
 #endif
 
-    return dma_sgl_get(vfu_ctx->dma, sgl, iov, cnt);
+    /* Check if any SGL entries are iommufd mappings (region == INT_MAX) */
+    sg = sgl;
+    for (i = 0; i < cnt; i++, sg++) {
+        if (sg->region == INT_MAX) {
+            /* This is an iommufd mapping - IOVA equals the server's virtual address */
+            if (vfu_ctx->iommufd == NULL || !iommufd_is_enabled(vfu_ctx->iommufd)) {
+                return ERROR_INT(EINVAL);
+            }
+
+            /* In iommufd mode, IOVA equals the server's virtual address, so use it directly */
+            iov[i].iov_base = sg->dma_addr;
+            iov[i].iov_len = sg->length;
+        } else {
+            /* Legacy DMA mapping - use existing dma_sgl_get logic */
+            if (sg->region >= vfu_ctx->dma->nregions) {
+                return ERROR_INT(EINVAL);
+            }
+
+            dma_memory_region_t *region = &vfu_ctx->dma->regions[sg->region];
+            if (region->info.vaddr == NULL) {
+                return ERROR_INT(EFAULT);
+            }
+
+            iov[i].iov_base = (uint8_t *)region->info.vaddr + sg->offset;
+            iov[i].iov_len = sg->length;
+        }
+    }
+
+    return 0;
 }
 
 EXPORT void
@@ -2399,6 +2503,223 @@ EXPORT bool
 vfu_sg_is_mappable(vfu_ctx_t *vfu_ctx, dma_sg_t *sg)
 {
     return dma_sg_is_mappable(vfu_ctx->dma, sg);
+}
+
+/* iommufd command handler implementations */
+
+static int
+handle_iommufd_alloc_ioas(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_alloc_ioas *req, reply;
+    uint32_t ioas_id;
+    int ret;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_ALLOC_IOAS: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_ALLOC_IOAS: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    ret = iommufd_alloc_ioas(vfu_ctx->iommufd, &ioas_id);
+    if (ret < 0) {
+        return ret;
+    }
+
+    memset(&reply, 0, sizeof(reply));
+    reply.out_ioas_id = ioas_id;
+
+    msg->out.iov.iov_base = &reply;
+    msg->out.iov.iov_len = sizeof(reply);
+
+    return 0;
+}
+
+static int
+handle_iommufd_destroy_ioas(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_destroy_ioas *req;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_DESTROY_IOAS: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_DESTROY_IOAS: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    return iommufd_destroy_ioas(vfu_ctx->iommufd, req->ioas_id);
+}
+
+static int
+handle_iommufd_bind(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_bind *req, reply;
+    int ret;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_BIND: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_BIND: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    ret = iommufd_bind_device(vfu_ctx->iommufd);
+    if (ret < 0) {
+        return ret;
+    }
+
+    /* Return a dummy device ID (not used in vfio-user) */
+    memset(&reply, 0, sizeof(reply));
+    reply.out_devid = 1;
+
+    msg->out.iov.iov_base = &reply;
+    msg->out.iov.iov_len = sizeof(reply);
+
+    return 0;
+}
+
+static int
+handle_iommufd_attach_pt(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_attach_pt *req;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_ATTACH_PT: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_ATTACH_PT: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    return iommufd_attach_ioas(vfu_ctx->iommufd, req->pt_id);
+}
+
+static int
+handle_iommufd_detach_pt(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_DETACH_PT: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    return iommufd_detach_ioas(vfu_ctx->iommufd);
+}
+
+static int
+handle_iommufd_ioas_map(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_ioas_map *req, reply;
+    uint64_t iova;
+    int fd = -1;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_MAP: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_MAP: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    /* Expect exactly one fd */
+    if (msg->in.nr_fds != 1) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_MAP: expected 1 fd, got %zu",
+                msg->in.nr_fds);
+        return ERROR_INT(EINVAL);
+    }
+
+    fd = consume_fd(msg->in.fds, msg->in.nr_fds, 0);
+    if (fd < 0) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_MAP: failed to consume fd");
+        return ERROR_INT(EINVAL);
+    }
+
+    /* Map the memory and get back the IOVA (server's vaddr) */
+    iova = iommufd_map_iova(vfu_ctx->iommufd, req->ioas_id, req->user_va,
+                            req->length, req->offset, req->flags, fd);
+    if (iova == 0) {
+        close(fd);
+        return ERROR_INT(errno);
+    }
+
+    /* Reply with the allocated IOVA */
+    memcpy(&reply, req, sizeof(reply));
+    reply.iova = iova;
+
+    msg->out.iov.iov_base = &reply;
+    msg->out.iov.iov_len = sizeof(reply);
+
+    return 0;
+}
+
+static int
+handle_iommufd_ioas_unmap(vfu_ctx_t *vfu_ctx, vfu_msg_t *msg)
+{
+    struct vfio_user_iommufd_ioas_unmap *req;
+
+    assert(vfu_ctx != NULL);
+    assert(msg != NULL);
+
+    if (msg->in.iov.iov_len < sizeof(*req)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_UNMAP: bad size %zu",
+                msg->in.iov.iov_len);
+        return ERROR_INT(EINVAL);
+    }
+
+    req = msg->in.iov.iov_base;
+
+    if (!iommufd_is_enabled(vfu_ctx->iommufd)) {
+        vfu_log(vfu_ctx, LOG_ERR, "IOMMUFD_IOAS_UNMAP: iommufd not enabled");
+        return ERROR_INT(EINVAL);
+    }
+
+    return iommufd_unmap_iova(vfu_ctx->iommufd, req->ioas_id, req->iova,
+                              req->length);
 }
 
 EXPORT int

--- a/lib/meson.build
+++ b/lib/meson.build
@@ -5,6 +5,7 @@ libvfio_user_cflags = []
 
 libvfio_user_sources = [
     'dma.c',
+    'iommufd.c',
     'irq.c',
     'libvfio-user.c',
     'migration.c',

--- a/lib/private.h
+++ b/lib/private.h
@@ -128,6 +128,7 @@ struct pci_dev {
 };
 
 struct dma_controller;
+struct iommufd_controller;
 
 enum vfu_ctx_pending_state {
     VFU_CTX_PENDING_NONE,
@@ -156,6 +157,7 @@ enum cb_type {
 struct vfu_ctx {
     void                    *pvt;
     struct dma_controller   *dma;
+    struct iommufd_controller *iommufd;
     int                     log_level;
     vfu_log_fn_t            *log;
     size_t                  nr_regions;

--- a/lib/tran.c
+++ b/lib/tran.c
@@ -40,6 +40,7 @@
 
 #include <json.h>
 
+#include "iommufd.h"
 #include "libvfio-user.h"
 #include "migration.h"
 #include "tran.h"
@@ -60,6 +61,9 @@
  *         "twin_socket": {
  *             "supported": true,
  *             "fd_index": 0
+ *         },
+ *         "iommufd": {
+ *             "supported": true
  *         }
  *     }
  * }
@@ -70,7 +74,7 @@
 int
 tran_parse_version_json(const char *json_str, int *client_max_fdsp,
                         size_t *client_max_data_xfer_sizep, size_t *pgsizep,
-                        bool *twin_socket_supportedp)
+                        bool *twin_socket_supportedp, bool *iommufd_supportedp)
 {
     struct json_object *jo_caps = NULL;
     struct json_object *jo_top = NULL;
@@ -157,6 +161,28 @@ tran_parse_version_json(const char *json_str, int *client_max_fdsp,
         }
     }
 
+    if (iommufd_supportedp != NULL &&
+        json_object_object_get_ex(jo_caps, "iommufd", &jo)) {
+        struct json_object *jo2 = NULL;
+
+        if (json_object_get_type(jo) != json_type_object) {
+            goto out;
+        }
+
+        if (json_object_object_get_ex(jo, "supported", &jo2)) {
+            if (json_object_get_type(jo2) != json_type_boolean) {
+                goto out;
+            }
+
+            errno = 0;
+            *iommufd_supportedp = json_object_get_boolean(jo2);
+
+            if (errno != 0) {
+                goto out;
+            }
+        }
+    }
+
     ret = 0;
 
 out:
@@ -170,7 +196,8 @@ out:
 
 static int
 recv_version(vfu_ctx_t *vfu_ctx, uint16_t *msg_idp,
-             struct vfio_user_version **versionp, bool *twin_socket_supportedp)
+             struct vfio_user_version **versionp, bool *twin_socket_supportedp,
+             bool *iommufd_supportedp)
 {
     struct vfio_user_version *cversion = NULL;
     vfu_msg_t msg = { { 0 } };
@@ -235,7 +262,8 @@ recv_version(vfu_ctx_t *vfu_ctx, uint16_t *msg_idp,
 
         ret = tran_parse_version_json(json_str, &vfu_ctx->client_max_fds,
                                       &vfu_ctx->client_max_data_xfer_size,
-                                      &pgsize, twin_socket_supportedp);
+                                      &pgsize, twin_socket_supportedp,
+                                      iommufd_supportedp);
 
         if (ret < 0) {
             /* No client-supplied strings in the log for release build. */
@@ -339,9 +367,11 @@ json_add_uint64(struct json_object *jso, const char *key, uint64_t value)
  * be freed by the caller.
  */
 static char *
-format_server_capabilities(vfu_ctx_t *vfu_ctx, int twin_socket_fd_index)
+format_server_capabilities(vfu_ctx_t *vfu_ctx, int twin_socket_fd_index,
+                            bool iommufd_supported)
 {
     struct json_object *jo_twin_socket = NULL;
+    struct json_object *jo_iommufd = NULL;
     struct json_object *jo_migration = NULL;
     struct json_object *jo_caps = NULL;
     struct json_object *jo_top = NULL;
@@ -394,6 +424,23 @@ format_server_capabilities(vfu_ctx_t *vfu_ctx, int twin_socket_fd_index)
         }
     }
 
+    if (iommufd_supported) {
+        struct json_object *jo_supported = NULL;
+
+        if ((jo_iommufd = json_object_new_object()) == NULL) {
+            goto out;
+        }
+
+        if ((jo_supported = json_object_new_boolean(true)) == NULL ||
+            json_add(jo_iommufd, "supported", &jo_supported) < 0) {
+            goto out;
+        }
+
+        if (json_add(jo_caps, "iommufd", &jo_iommufd) < 0) {
+            goto out;
+        }
+    }
+
     if ((jo_top = json_object_new_object()) == NULL ||
         json_add(jo_top, "capabilities", &jo_caps) < 0) {
         goto out;
@@ -403,6 +450,7 @@ format_server_capabilities(vfu_ctx_t *vfu_ctx, int twin_socket_fd_index)
 
 out:
     json_object_put(jo_twin_socket);
+    json_object_put(jo_iommufd);
     json_object_put(jo_migration);
     json_object_put(jo_caps);
     json_object_put(jo_top);
@@ -411,7 +459,8 @@ out:
 
 static int
 send_version(vfu_ctx_t *vfu_ctx, uint16_t msg_id,
-             struct vfio_user_version *cversion, int client_cmd_socket_fd)
+             struct vfio_user_version *cversion, int client_cmd_socket_fd,
+             bool iommufd_supported)
 {
     int twin_socket_fd_index = client_cmd_socket_fd >= 0 ? 0 : -1;
     struct vfio_user_version sversion = { 0 };
@@ -420,7 +469,8 @@ send_version(vfu_ctx_t *vfu_ctx, uint16_t msg_id,
     char *server_caps = NULL;
     int ret;
 
-    server_caps = format_server_capabilities(vfu_ctx, twin_socket_fd_index);
+    server_caps = format_server_capabilities(vfu_ctx, twin_socket_fd_index,
+                                             iommufd_supported);
     if (server_caps == NULL) {
         errno = ENOMEM;
         return -1;
@@ -458,11 +508,12 @@ tran_negotiate(vfu_ctx_t *vfu_ctx, int *client_cmd_socket_fdp)
     struct vfio_user_version *client_version = NULL;
     int client_cmd_socket_fds[2] = { -1, -1 };
     bool twin_socket_supported = false;
+    bool iommufd_supported = false;
     uint16_t msg_id = 0x0bad;
     int ret;
 
     ret = recv_version(vfu_ctx, &msg_id, &client_version,
-                       &twin_socket_supported);
+                       &twin_socket_supported, &iommufd_supported);
 
     if (ret < 0) {
         vfu_log(vfu_ctx, LOG_ERR, "failed to recv version: %m");
@@ -478,7 +529,7 @@ tran_negotiate(vfu_ctx_t *vfu_ctx, int *client_cmd_socket_fdp)
     }
 
     ret = send_version(vfu_ctx, msg_id, client_version,
-                       client_cmd_socket_fds[0]);
+                       client_cmd_socket_fds[0], iommufd_supported);
 
     free(client_version);
 
@@ -490,8 +541,14 @@ tran_negotiate(vfu_ctx_t *vfu_ctx, int *client_cmd_socket_fdp)
     if (ret < 0) {
         vfu_log(vfu_ctx, LOG_ERR, "failed to send version: %m");
         close_safely(&client_cmd_socket_fds[1]);
-    } else if (client_cmd_socket_fdp != NULL) {
-        *client_cmd_socket_fdp = client_cmd_socket_fds[1];
+    } else {
+        if (client_cmd_socket_fdp != NULL) {
+            *client_cmd_socket_fdp = client_cmd_socket_fds[1];
+        }
+        /* Enable iommufd mode if both client and server support it */
+        if (iommufd_supported && vfu_ctx->iommufd != NULL) {
+            iommufd_enable(vfu_ctx->iommufd);
+        }
     }
 
     return ret;

--- a/lib/tran.h
+++ b/lib/tran.h
@@ -73,7 +73,7 @@ struct transport_ops {
 int
 tran_parse_version_json(const char *json_str, int *client_max_fdsp,
                         size_t *client_max_data_xfer_sizep, size_t *pgsizep,
-                        bool *twin_socket_supportedp);
+                        bool *twin_socket_supportedp, bool *iommufd_supportedp);
 
 int
 tran_negotiate(vfu_ctx_t *vfu_ctx, int *client_cmd_socket_fdp);

--- a/samples/client.c
+++ b/samples/client.c
@@ -197,7 +197,8 @@ recv_version(int sock, int *server_max_fds, size_t *server_max_data_xfer_size,
         }
 
         ret = tran_parse_version_json(json_str, server_max_fds,
-                                      server_max_data_xfer_size, pgsize, NULL);
+                                      server_max_data_xfer_size, pgsize, NULL,
+                                      NULL);
 
         if (ret < 0) {
             err(EXIT_FAILURE, "failed to parse server JSON \"%s\"", json_str);

--- a/samples/meson.build
+++ b/samples/meson.build
@@ -1,6 +1,7 @@
 
 client_sources = [
     'client.c',
+    '../lib/iommufd.c',
     '../lib/migration.c',
     '../lib/tran.c',
     '../lib/tran_sock.c',

--- a/test/lspci.expected.out.5
+++ b/test/lspci.expected.out.5
@@ -1,0 +1,30 @@
+00:00.0 Non-VGA unclassified device: Device 0000:0000
+	Control: I/O- Mem- BusMaster- SpecCycle- MemWINV- VGASnoop- ParErr- Stepping- SERR- FastB2B- DisINTx-
+	Status: Cap+ 66MHz- UDF- FastB2B- ParErr- DEVSEL=fast >TAbort- <TAbort- <MAbort- >SERR- <PERR- INTx-
+	Region 0: I/O ports at <unassigned> [disabled]
+	Region 1: I/O ports at <unassigned> [disabled]
+	Region 2: I/O ports at <unassigned> [disabled]
+	Region 3: I/O ports at <unassigned> [disabled]
+	Region 4: I/O ports at <unassigned> [disabled]
+	Region 5: I/O ports at <unassigned> [disabled]
+	Capabilities: [40] Power Management version 0
+		Flags: PMEClk- DSI- D1- D2- AuxCurrent=0mA PME(D0-,D1-,D2-,D3hot-,D3cold-)
+		Status: D0 NoSoftRst+ PME-Enable- DSel=0 DScale=0 PME-
+	Capabilities: [48] Vendor Specific Information: Len=10 <?>
+	Capabilities: [58] Express (v0) Endpoint, IntMsgNum 0
+		DevCap:	MaxPayload 128 bytes, PhantFunc 0, Latency L0s <64ns, L1 <1us
+			ExtTag- AttnBtn- AttnInd- PwrInd- RBE- FLReset+ SlotPowerLimit 0W TEE-IO-
+		DevCtl:	CorrErr- NonFatalErr- FatalErr- UnsupReq-
+			RlxdOrd- ExtTag- PhantFunc- AuxPwr- NoSnoop- FLReset-
+			MaxPayload 128 bytes, MaxReadReq 128 bytes
+		DevSta:	CorrErr- NonFatalErr- FatalErr- UnsupReq- AuxPwr- TransPend-
+		LnkCap:	Port #0, Speed unknown, Width x0, ASPM not supported
+			ClockPM- Surprise- LLActRep- BwNot- ASPMOptComp-
+		LnkCtl:	ASPM Disabled; RCB 64 bytes, LnkDisable- CommClk-
+			ExtSynch- ClockPM- AutWidDis- BWInt- AutBWInt- FltModeDis-
+		LnkSta:	Speed unknown, Width x0
+			TrErr- Train- SlotClk- DLActive- BWMgmt- ABWMgmt-
+	Capabilities: [100 v0] Device Serial Number ca-fe-ba-be-de-ad-be-ef
+	Capabilities: [10c v0] Vendor Specific Information: ID=0001 Rev=1 Len=015 <?>
+	Capabilities: [400 v0] Vendor Specific Information: ID=0002 Rev=2 Len=015 <?>
+

--- a/test/meson.build
+++ b/test/meson.build
@@ -27,6 +27,7 @@ unit_tests_sources = [
     'unit-tests.c',
     'mocks.c',
     '../lib/dma.c',
+    '../lib/iommufd.c',
     '../lib/irq.c',
     '../lib/libvfio-user.c',
     '../lib/migration.c',

--- a/test/test-lspci.sh
+++ b/test/test-lspci.sh
@@ -16,7 +16,7 @@ test -n "$1" && LSPCI="$1"
 
 $LSPCI | lspci -vv -F /dev/stdin >lspci.out
 
-for i in 1 2 3 4; do
+for i in 1 2 3 4 5; do
     if diff lspci.out $(dirname $0)/lspci.expected.out.$i >/dev/null 2>&1; then
         exit 0
     fi


### PR DESCRIPTION
Linux added a new uapi called IOMMUFD for managing the IOMMU. In recent Linux releases, many of the vfio ioctls are now just legacy wrappers around this new interface. However, the new interface has a couple of important features that I'd like to use with vfio-user. Namely:
1) Support for allowing the server to allocate the IOVA. This is important because the server can return the true IOVA to the client directly, which can be used as an actual DMA address by hardware. If the client puts this address into a command, they don't have to rely on the server process to intercept the command and translate it.
2) Support for registering memory described by a dma-buf (e.g. memory on another PCI device)

I've tried to make this backward compatible by adding feature negotiation. Only if both client and server report support will it be used.