### PR TITLE
Free dirty_bitmap when unmapping DMA region to fix memory leak

### DIFF
--- a/lib/dma.c
+++ b/lib/dma.c
@@ -135,6 +135,11 @@ MOCK_DEFINE(dma_controller_unmap_region)(dma_controller_t *dma,
 
     assert(region->fd != -1);
 
+    if (region->dirty_bitmap != NULL) {
+        free(region->dirty_bitmap);
+        region->dirty_bitmap = NULL;
+    }
+
     err = fd_cache_put(&region->fd);
     assert(err == 0);
 }


### PR DESCRIPTION
The dirty bitmap was allocated when dirty tracking is enabled for a DMA region, but was not released during region teardown, may lead to memory leaks over time.