### PR TITLE
scan-build fixes

### DIFF
--- a/lib/dma.h
+++ b/lib/dma.h
@@ -256,6 +256,7 @@ dma_addr_to_sgl(const dma_controller_t *dma,
      * workload at 512b block size.
      */
     if (likely(thread_generation == dma_generation &&
+               region_hint != NULL &&
                max_nr_sgs > 0 && len > 0 &&
                dma_addr >= region_hint->info.iova.iov_base &&
                dma_addr + len <= iov_end(&region_hint->info.iova))) {

--- a/test/btree_unit_tests.c
+++ b/test/btree_unit_tests.c
@@ -113,10 +113,9 @@ test_insert_randomized()
         /* Iterate the tree and verify the inserted elements are present. */
         int pos = 0;
         uintptr_t key = -1;
-        void *value;
         btree_iter_t iter;
         for (btree_iter_init(&tree, 0, &iter);
-             (value = btree_iter_get(&iter, &key)) != NULL;
+             btree_iter_get(&iter, &key) != NULL;
              btree_iter_next(&iter)) {
             for (uintptr_t p = pos; p < key; ++p) {
                 assert(!present[p]);


### PR DESCRIPTION
Fix scan-build issues

In file included from ../../../../lib/dma.c:43:
../../../../lib/dma.h:260:28: warning: Dereference of null pointer [core.NullDereference]
  260 |                dma_addr >= region_hint->info.iova.iov_base &&
      |                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../lib/common.h:58:41: note: expanded from macro 'likely'
   58 | #define likely(e)   __builtin_expect(!!(e), 1)
      |                                         ^

[17/49] Compiling C object test/btree_unit_tests.p/btree_unit_tests.c.o
../../../../test/btree_unit_tests.c:119:15: warning: Although the value stored to 'value' is used in the enclosing expression, the value is never actually read from 'value' [deadcode.DeadStores]
  119 |              (value = btree_iter_get(&iter, &key)) != NULL;
      |               ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~

Neither of these are actual production issues, but let's clean the lint.

Signed-off-by: John Levon <john.levon@nutanix.com>

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>