### PR TITLE
Fix scan-build lint

### DIFF
--- a/lib/tran_sock.c
+++ b/lib/tran_sock.c
@@ -100,7 +100,9 @@ tran_sock_send_iovec(int sock, uint16_t msg_id, bool is_reply,
         msg.msg_control = buf;
         msg.msg_controllen = CMSG_SPACE(size);
 
-        struct cmsghdr * cmsg = CMSG_FIRSTHDR(&msg);
+        struct cmsghdr *cmsg = CMSG_FIRSTHDR(&msg);
+        /* Quieten clang-analyzer. */
+        assert(cmsg != NULL);
         cmsg->cmsg_level = SOL_SOCKET;
         cmsg->cmsg_type = SCM_RIGHTS;
         cmsg->cmsg_len = CMSG_LEN(size);


### PR DESCRIPTION
On the CentOS 7 build, scan-build incorrectly reports:

../../../../lib/tran_sock.c:104:26: warning: Access to field 'cmsg_level' results in a dereference of a null pointer (loaded from variable 'cmsg')

Add an assert for this.

Signed-off-by: John Levon <john.levon@nutanix.com>
