### PR TITLE
do not reset migration state on device reset (#844)

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -888,16 +888,12 @@ static int
 device_reset(vfu_ctx_t *vfu_ctx, vfu_reset_type_t reason)
 {
     int ret;
-    
+
     ret = call_reset_cb(vfu_ctx, reason);
     if (ret < 0) {
         return ret;
     }
 
-    if (vfu_ctx->migration != NULL) {
-        migr_state_transition(vfu_ctx->migration,
-                              VFIO_USER_DEVICE_STATE_RUNNING);
-    }
     return 0;
 }
 


### PR DESCRIPTION
Unconditionally resetting migration state to RUNNING on device reset caused desynchronization with migration initiators(e.g. QEMU) when a reset occurred during the pre-copy phase, leading to invalid state transitions and aborted migrations.

The reset operation should only discard captured device state, not modify the active migration state machine.