### PR TITLE
Replace deprecated cmocka macros in unit tests

### DIFF
--- a/test/mocks.c
+++ b/test/mocks.c
@@ -123,10 +123,10 @@ dma_controller_add_region(dma_controller_t *dma, void *dma_addr,
 
     check_expected_ptr(dma);
     check_expected_ptr(dma_addr);
-    check_expected(size);
-    check_expected(fd);
-    check_expected(offset);
-    check_expected(prot);
+    check_expected_uint(size);
+    check_expected_int(fd);
+    check_expected_int(offset);
+    check_expected_uint(prot);
     errno = mock();
     return mock_ptr_type(dma_memory_region_t *);
 }
@@ -142,11 +142,11 @@ dma_controller_remove_region(dma_controller_t *dma,
                                                    dma_unregister, data);
     }
 
-    check_expected(dma);
-    check_expected(dma_addr);
-    check_expected(size);
-    check_expected(dma_unregister);
-    check_expected(data);
+    check_expected_ptr(dma);
+    check_expected_ptr(dma_addr);
+    check_expected_uint(size);
+    check_expected_ptr(dma_unregister);
+    check_expected_ptr(data);
     return mock();
 }
 
@@ -154,8 +154,8 @@ void
 dma_controller_unmap_region(dma_controller_t *dma,
                             dma_memory_region_t *region)
 {
-    check_expected(dma);
-    check_expected(region);
+    check_expected_ptr(dma);
+    check_expected_ptr(region);
 }
 
 bool
@@ -164,7 +164,7 @@ device_is_stopped(struct migration *migration)
     if (!is_patched("device_is_stopped")) {
         return __real_device_is_stopped(migration);
     }
-    check_expected(migration);
+    check_expected_ptr(migration);
     return mock();
 }
 
@@ -174,7 +174,7 @@ device_is_stopped_and_copying(struct migration *migration)
     if (!is_patched("device_is_stopped_and_copying")) {
         return __real_device_is_stopped_and_copying(migration);
     }
-    check_expected(migration);
+    check_expected_ptr(migration);
     return mock();
 }
 
@@ -184,7 +184,7 @@ cmd_allowed_when_stopped_and_copying(uint16_t cmd)
     if (!is_patched("cmd_allowed_when_stopped_and_copying")) {
         return __real_cmd_allowed_when_stopped_and_copying(cmd);
     }
-    check_expected(cmd);
+    check_expected_uint(cmd);
     return mock();
 }
 
@@ -194,8 +194,8 @@ should_exec_command(vfu_ctx_t *vfu_ctx, uint16_t cmd)
     if (!is_patched("should_exec_command")) {
         return __real_should_exec_command(vfu_ctx, cmd);
     }
-    check_expected(vfu_ctx);
-    check_expected(cmd);
+    check_expected_ptr(vfu_ctx);
+    check_expected_uint(cmd);
     return mock();
 }
 
@@ -207,10 +207,10 @@ handle_device_state(vfu_ctx_t *vfu_ctx, struct migration *migr,
         return __real_handle_device_state(vfu_ctx, migr, device_state,
                                           notify);
     }
-    check_expected(vfu_ctx);
-    check_expected(migr);
-    check_expected(device_state);
-    check_expected(notify);
+    check_expected_ptr(vfu_ctx);
+    check_expected_ptr(migr);
+    check_expected_uint(device_state);
+    check_expected_int(notify);
     return mock();
 }
 
@@ -222,8 +222,8 @@ migr_state_transition(struct migration *migr,
         __real_migr_state_transition(migr, state);
         return;
     }
-    check_expected(migr);
-    check_expected(state);
+    check_expected_ptr(migr);
+    check_expected_int(state);
 }
 
 bool
@@ -232,8 +232,8 @@ vfio_migr_state_transition_is_valid(uint32_t from, uint32_t to)
     if (!is_patched("vfio_migr_state_transition_is_valid")) {
         return __real_vfio_migr_state_transition_is_valid(from, to);
     }
-    check_expected(from);
-    check_expected(to);
+    check_expected_uint(from);
+    check_expected_uint(to);
     return mock();
 }
 
@@ -244,9 +244,9 @@ state_trans_notify(vfu_ctx_t *vfu_ctx, int (*fn)(vfu_ctx_t*, vfu_migr_state_t),
     if (!is_patched("state_trans_notify")) {
         return __real_state_trans_notify(vfu_ctx, fn, vfio_device_state);
     }
-    check_expected(vfu_ctx);
-    check_expected(fn);
-    check_expected(vfio_device_state);
+    check_expected_ptr(vfu_ctx);
+    check_expected_ptr(fn);
+    check_expected_uint(vfio_device_state);
     errno = mock();
     return mock();
 }
@@ -259,10 +259,10 @@ migr_trans_to_valid_state(vfu_ctx_t *vfu_ctx, struct migration *migr,
         return __real_migr_trans_to_valid_state(vfu_ctx, migr, device_state,
                                                 notify);
     }
-    check_expected(vfu_ctx);
-    check_expected(migr);
-    check_expected(device_state);
-    check_expected(notify);
+    check_expected_ptr(vfu_ctx);
+    check_expected_ptr(migr);
+    check_expected_uint(device_state);
+    check_expected_int(notify);
     return mock();
 }
 
@@ -272,7 +272,7 @@ migr_state_vfio_to_vfu(uint32_t vfio_device_state)
     if (!is_patched("migr_state_vfio_to_vfu")) {
         return __real_migr_state_vfio_to_vfu(vfio_device_state);
     }
-    check_expected(vfio_device_state);
+    check_expected_uint(vfio_device_state);
     return mock();
 }
 
@@ -280,22 +280,22 @@ migr_state_vfio_to_vfu(uint32_t vfio_device_state)
 void
 mock_dma_register(vfu_ctx_t *vfu_ctx, vfu_dma_info_t *info)
 {
-    check_expected(vfu_ctx);
-    check_expected(info);
+    check_expected_ptr(vfu_ctx);
+    check_expected_ptr(info);
 }
 
 void
 mock_dma_unregister(vfu_ctx_t *vfu_ctx, vfu_dma_info_t *info)
 {
-    check_expected(vfu_ctx);
-    check_expected(info);
+    check_expected_ptr(vfu_ctx);
+    check_expected_ptr(info);
 }
 
 int
 mock_reset_cb(vfu_ctx_t *vfu_ctx, vfu_reset_type_t type)
 {
-    check_expected(vfu_ctx);
-    check_expected(type);
+    check_expected_ptr(vfu_ctx);
+    check_expected_int(type);
     return mock();
 }
 
@@ -303,8 +303,8 @@ mock_reset_cb(vfu_ctx_t *vfu_ctx, vfu_reset_type_t type)
 int
 mock_notify_migr_state_trans_cb(vfu_ctx_t *vfu_ctx, vfu_migr_state_t vfu_state)
 {
-    check_expected(vfu_ctx);
-    check_expected(vfu_state);
+    check_expected_ptr(vfu_ctx);
+    check_expected_int(vfu_state);
     return mock();
 }
 
@@ -328,7 +328,7 @@ close(int fd)
         return __real_close(fd);
     }
 
-    check_expected(fd);
+    check_expected_int(fd);
     return mock();
 }
 

--- a/test/mocks.h
+++ b/test/mocks.h
@@ -30,6 +30,47 @@
 
 #include "private.h"
 
+/*
+ * Since <cmocka_version.h> is unavailable in CMocka versions prior to 2.0.0,
+ * the presence of the expect_check_data() macro is used instead to determine
+ * the current API version of CMocka.
+ */
+#ifndef expect_check_data
+
+/*
+ * In CMocka 1.x, the callback function (check_function) for expect_check()
+ * requires parameters of LargestIntegralType, whereas in CMocka 2.x, both
+ * expect_check() and LargestIntegralType are deprecated, and the callback
+ * function for expect_check_data() requires parameters with the type of
+ * CMockaValueData, which is incompatible with LargestIntegralType.
+ *
+ * Therefore, this typedef is required to maintain compatibility between
+ * different CMocka versions, while minimizing changes to the existing
+ * unit tests.
+ */
+typedef uintmax_t CMockaValueData;
+
+#define cast_ptr_to_cmocka_value(value)       ((uintptr_t)(value))
+#define extract_uint_from_cmocka_value(value) (value)
+
+#define check_expected_int(parameter) \
+    check_expected(parameter)
+
+#define check_expected_uint(parameter) \
+    check_expected(parameter)
+
+#define expect_check_data(function, parameter, check_function, check_data) \
+    expect_check(function, parameter, check_function, check_data)
+
+#define expect_int_value(function, parameter, value) \
+    expect_value(function, parameter, value)
+
+#define expect_uint_value(function, parameter, value) \
+    expect_value(function, parameter, value)
+#else
+#define extract_uint_from_cmocka_value(value) ((value).uint_val)
+#endif
+
 void unpatch_all(void);
 
 void patch(const char *name);

--- a/test/unit-tests.c
+++ b/test/unit-tests.c
@@ -159,12 +159,12 @@ test_dma_map_without_fd(void **state UNUSED)
     patch("dma_controller_add_region");
     will_return(dma_controller_add_region, 0xfa4e);
     will_return(dma_controller_add_region, 0xfa4e);
-    expect_value(dma_controller_add_region, dma, vfu_ctx.dma);
-    expect_value(dma_controller_add_region, dma_addr, dma_map.addr);
-    expect_value(dma_controller_add_region, size, dma_map.size);
-    expect_value(dma_controller_add_region, fd, -1);
-    expect_value(dma_controller_add_region, offset, dma_map.offset);
-    expect_value(dma_controller_add_region, prot, PROT_NONE);
+    expect_uint_value(dma_controller_add_region, dma, (uintptr_t)vfu_ctx.dma);
+    expect_uint_value(dma_controller_add_region, dma_addr, (uintptr_t)dma_map.addr);
+    expect_uint_value(dma_controller_add_region, size, dma_map.size);
+    expect_int_value(dma_controller_add_region, fd, -1);
+    expect_int_value(dma_controller_add_region, offset, dma_map.offset);
+    expect_uint_value(dma_controller_add_region, prot, PROT_NONE);
     ret = handle_dma_map(&vfu_ctx,
                          mkmsg(VFIO_USER_DMA_MAP, &dma_map, sizeof(dma_map)),
                          &dma_map);
@@ -172,11 +172,13 @@ test_dma_map_without_fd(void **state UNUSED)
 }
 
 static int
-check_dma_info(const LargestIntegralType value,
-               const LargestIntegralType cvalue)
+check_dma_info(const CMockaValueData value,
+               const CMockaValueData cvalue)
 {
-    vfu_dma_info_t *info = (vfu_dma_info_t *)(long)value;
-    vfu_dma_info_t *cinfo = (vfu_dma_info_t *)(long)cvalue;
+    vfu_dma_info_t *info = 
+        (vfu_dma_info_t *)(long)extract_uint_from_cmocka_value(value);
+    vfu_dma_info_t *cinfo = 
+        (vfu_dma_info_t *)(long)extract_uint_from_cmocka_value(cvalue);
 
     return info->iova.iov_base == cinfo->iova.iov_base &&
         info->iova.iov_len == cinfo->iova.iov_len &&
@@ -188,13 +190,16 @@ check_dma_info(const LargestIntegralType value,
 }
 
 static int
-check_dma_region(const LargestIntegralType value,
-                 const LargestIntegralType cvalue)
+check_dma_region(const CMockaValueData value,
+                 const CMockaValueData cvalue)
 {
-    dma_memory_region_t *region = (dma_memory_region_t *)(long)value;
-    dma_memory_region_t *cregion = (dma_memory_region_t *)(long)cvalue;
+    dma_memory_region_t *region = 
+        (dma_memory_region_t *)(long)extract_uint_from_cmocka_value(value);
+    dma_memory_region_t *cregion = 
+        (dma_memory_region_t *)(long)extract_uint_from_cmocka_value(cvalue);
 
-    return check_dma_info((uintptr_t)&region->info, (uintptr_t) &cregion->info) &&
+    return check_dma_info(cast_ptr_to_cmocka_value(&region->info), 
+        cast_ptr_to_cmocka_value(&cregion->info)) &&
         region->fd == cregion->fd &&
         region->offset == cregion->offset;
 }
@@ -225,7 +230,8 @@ verify_dma_region(dma_controller_t *dma, dma_memory_region_t *region)
     assert_non_null(entry);
 
     assert_int_equal(
-        1, check_dma_info((uintptr_t)&entry->info, (uintptr_t)&region->info));
+        1, check_dma_info(cast_ptr_to_cmocka_value(&entry->info), 
+                          cast_ptr_to_cmocka_value(&region->info)));
 }
 
 /*
@@ -243,12 +249,12 @@ test_dma_map_return_value(void **state UNUSED)
     };
 
     patch("dma_controller_add_region");
-    expect_value(dma_controller_add_region, dma, (uintptr_t)vfu_ctx.dma);
-    expect_value(dma_controller_add_region, dma_addr, dma_map.addr);
-    expect_value(dma_controller_add_region, size, dma_map.size);
-    expect_value(dma_controller_add_region, fd, -1);
-    expect_value(dma_controller_add_region, offset, dma_map.offset);
-    expect_value(dma_controller_add_region, prot, PROT_NONE);
+    expect_uint_value(dma_controller_add_region, dma, (uintptr_t)vfu_ctx.dma);
+    expect_uint_value(dma_controller_add_region, dma_addr, (uintptr_t) dma_map.addr);
+    expect_uint_value(dma_controller_add_region, size, dma_map.size);
+    expect_int_value(dma_controller_add_region, fd, -1);
+    expect_int_value(dma_controller_add_region, offset, dma_map.offset);
+    expect_uint_value(dma_controller_add_region, prot, PROT_NONE);
     will_return(dma_controller_add_region, 0);
     will_return(dma_controller_add_region, 2);
 
@@ -293,8 +299,9 @@ test_handle_dma_unmap(void **state UNUSED)
 
     vfu_ctx.dma_unregister = mock_dma_unregister;
 
-    expect_value(mock_dma_unregister, vfu_ctx, &vfu_ctx);
-    expect_check(mock_dma_unregister, info, check_dma_info, &regions[0].info);
+    expect_uint_value(mock_dma_unregister, vfu_ctx, (uintptr_t)&vfu_ctx);
+    expect_check_data(mock_dma_unregister, info, check_dma_info, 
+                      cast_ptr_to_cmocka_value(&regions[0].info));
 
     ret = handle_dma_unmap(&vfu_ctx,
                            mkmsg(VFIO_USER_DMA_UNMAP, &dma_unmap,
@@ -418,13 +425,14 @@ test_dma_controller_remove_region_mapped(void **state UNUSED)
     };
     stage_dma_region(vfu_ctx.dma, &region);
 
-    expect_value(mock_dma_unregister, vfu_ctx, &vfu_ctx);
-    expect_check(mock_dma_unregister, info, check_dma_info, &region);
+    expect_uint_value(mock_dma_unregister, vfu_ctx, (uintptr_t)&vfu_ctx);
+    expect_check_data(mock_dma_unregister, info, check_dma_info,
+                      cast_ptr_to_cmocka_value(&region));
     /* FIXME add unit test when dma_unregister fails */
     patch("dma_controller_unmap_region");
-    expect_value(dma_controller_unmap_region, dma, vfu_ctx.dma);
-    expect_check(dma_controller_unmap_region, region, check_dma_region,
-                 &region);
+    expect_uint_value(dma_controller_unmap_region, dma, (uintptr_t)vfu_ctx.dma);
+    expect_check_data(dma_controller_unmap_region, region, check_dma_region,
+                      cast_ptr_to_cmocka_value(&region));
     assert_int_equal(0,
         dma_controller_remove_region(vfu_ctx.dma, (void *)0xdeadbeef, 0x100,
             mock_dma_unregister, &vfu_ctx));
@@ -440,8 +448,9 @@ test_dma_controller_remove_region_unmapped(void **state UNUSED)
     };
     stage_dma_region(vfu_ctx.dma, &region);
 
-    expect_value(mock_dma_unregister, vfu_ctx, &vfu_ctx);
-    expect_check(mock_dma_unregister, info, check_dma_info, &region.info);
+    expect_uint_value(mock_dma_unregister, vfu_ctx, (uintptr_t)&vfu_ctx);
+    expect_check_data(mock_dma_unregister, info, check_dma_info, 
+                      cast_ptr_to_cmocka_value(&region.info));
     patch("dma_controller_unmap_region");
     assert_int_equal(0,
         dma_controller_remove_region(vfu_ctx.dma, (void *)0xdeadbeef, 0x100,
@@ -603,9 +612,11 @@ test_should_exec_command(UNUSED void **state)
 
     /* TEST stopped and copying, command allowed */
     will_return(device_is_stopped_and_copying, true);
-    expect_value(device_is_stopped_and_copying, migration, &migration);
+    expect_uint_value(device_is_stopped_and_copying, 
+                      migration, 
+                      (uintptr_t)&migration);
     will_return(cmd_allowed_when_stopped_and_copying, true);
-    expect_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
+    expect_uint_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
     assert_true(should_exec_command(&vfu_ctx, 0xbeef));
 
     /* TEST stopped and copying, command not allowed */
@@ -619,9 +630,9 @@ test_should_exec_command(UNUSED void **state)
     will_return(device_is_stopped_and_copying, false);
     expect_any(device_is_stopped_and_copying, migration);
     will_return(device_is_stopped, true);
-    expect_value(device_is_stopped, migration, &migration);
+    expect_uint_value(device_is_stopped, migration, (uintptr_t)&migration);
     will_return(cmd_allowed_when_stopped_and_copying, false);
-    expect_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
+    expect_uint_value(cmd_allowed_when_stopped_and_copying, cmd, 0xbeef);
     assert_false(should_exec_command(&vfu_ctx, 0xbeef));
 
     /* TEST none of the above */


### PR DESCRIPTION
## Summary

This pull requests replaces cmocka macro functions (`check_expected()`, `expect_check()`, `expect_value()`) which have been deprecated since cmocka 2.0.0. (https://github.com/nutanix/libvfio-user/issues/856)

## Build Logs (with this PR applied)

### cmocka 1.1.0 (CentOS 7)

```
$ meson build
The Meson build system
Version: 0.53.0
Source dir: /home/jdeokkim/libvfio-user-patch-jdeokkim
Build dir: /home/jdeokkim/libvfio-user-patch-jdeokkim/build
Build type: native build
Project name: libvfio-user
Project version: 0.0.1
C compiler for the host machine: cc (gcc 4.8.5 "cc (GCC) 4.8.5 20150623 (Red Hat 4.8.5-44)")
C linker for the host machine: cc GNU ld.bfd 2.23.52.0.1-16
Host machine cpu family: x86_64
Host machine cpu: x86_64
Run-time dependency threads found: YES
Library dl found: YES
Found pkg-config: /bin/pkg-config (0.27.1)
Run-time dependency json-c found: YES 0.11
Found CMake: /usr/local/cmake/bin/cmake (3.4.0)
Run-time dependency cmocka found: YES 1.1.3
Program pytest-3 found: NO
Program flake8 found: NO
Program misspell-fixer found: NO
Program restructuredtext-lint found: NO
Program valgrind found: NO
Compiler for C supports arguments -Wno-missing-field-initializers -Wmissing-field-initializers: YES 
Compiler for C supports arguments -Wmissing-declarations: YES 
Compiler for C supports arguments -Wwrite-strings: YES 
Check usable header "linux/kcmp.h" : NO
Program test-lspci.sh found: YES (/home/jdeokkim/libvfio-user-patch-jdeokkim/test/test-lspci.sh)
Build targets in project: 10

Found ninja-1.5.1 at /usr/local/bin/ninja
```

```
$ ninja -C build
ninja: Entering directory `build'
[48/48] Linking target test/fd_cache_unit_tests.
```

```
$ ./build/test/unit_tests
[==========] Running 14 test(s).
[ RUN      ] test_dma_map_mappable_without_fd
[       OK ] test_dma_map_mappable_without_fd
[ RUN      ] test_dma_map_without_fd
[       OK ] test_dma_map_without_fd
[ RUN      ] test_dma_map_return_value
[       OK ] test_dma_map_return_value
[ RUN      ] test_handle_dma_unmap
[       OK ] test_handle_dma_unmap
[ RUN      ] test_dma_controller_add_region_no_fd
[       OK ] test_dma_controller_add_region_no_fd
[ RUN      ] test_dma_controller_add_region_fd_deduplication
[       OK ] test_dma_controller_add_region_fd_deduplication
[ RUN      ] test_dma_controller_add_region_twice
[       OK ] test_dma_controller_add_region_twice
[ RUN      ] test_dma_controller_remove_region_mapped
[       OK ] test_dma_controller_remove_region_mapped
[ RUN      ] test_dma_controller_remove_region_unmapped
[       OK ] test_dma_controller_remove_region_unmapped
[ RUN      ] test_dma_addr_to_sgl
[       OK ] test_dma_addr_to_sgl
[ RUN      ] test_vfu_setup_device_dma
[       OK ] test_vfu_setup_device_dma
[ RUN      ] test_device_is_stopped_and_copying
[       OK ] test_device_is_stopped_and_copying
[ RUN      ] test_cmd_allowed_when_stopped_and_copying
[       OK ] test_cmd_allowed_when_stopped_and_copying
[ RUN      ] test_should_exec_command
[       OK ] test_should_exec_command
[==========] 14 test(s) run.
[  PASSED  ] 14 test(s).
```

---

### cmocka 1.1.3 (Void Linux)

```
$ meson setup --reconfigure build
The Meson build system
Version: 1.9.1
Source dir: /home/jdeokkim/Workspace/libvfio-user
Build dir: /home/jdeokkim/Workspace/libvfio-user/build
Build type: native build
Project name: libvfio-user
Project version: 0.0.1
C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20250405")
C linker for the host machine: cc ld.bfd 2.44
Host machine cpu family: x86_64
Host machine cpu: x86_64
Run-time dependency threads found: YES
Library dl found: YES
Found pkg-config: YES (/usr/sbin/pkg-config) 0.29.2
Run-time dependency json-c found: YES 0.18

Run-time dependency cmocka found: YES 1.1.3

Program pytest-3 found: NO
Program flake8 found: NO
Program misspell-fixer found: NO
Program restructuredtext-lint found: NO
Program valgrind found: YES (/usr/sbin/valgrind)
Compiler for C supports arguments -Wno-missing-field-initializers: YES 
Compiler for C supports arguments -Wmissing-declarations: YES 
Compiler for C supports arguments -Wwrite-strings: YES 
Check usable header "linux/kcmp.h" : YES 
test/meson.build:20: WARNING: Project targets '>= 0.53.0' but uses feature introduced in '0.57.0': exclude_suites arg in add_test_setup.
Program test-lspci.sh found: YES (/home/jdeokkim/Workspace/libvfio-user/test/test-lspci.sh)
Program test-linkage.sh found: YES (/home/jdeokkim/Workspace/libvfio-user/test/test-linkage.sh)
test/py/meson.build:16: WARNING: Project targets '>= 0.53.0' but uses feature introduced in '0.57.0': exclude_suites arg in add_test_setup.
Build targets in project: 10
WARNING: Project specifies a minimum meson_version '>= 0.53.0' but uses features which were added in newer versions:
 * 0.57.0: {'exclude_suites arg in add_test_setup'}

Found ninja-1.13.2 at /usr/sbin/ninja
```

```
$ ninja -C build
ninja: Entering directory `build'
[48/48] Linking target samples/null
```

```
$ ./build/test/unit_tests
[==========] Running 14 test(s).
[ RUN      ] test_dma_map_mappable_without_fd
[       OK ] test_dma_map_mappable_without_fd
[ RUN      ] test_dma_map_without_fd
[       OK ] test_dma_map_without_fd
[ RUN      ] test_dma_map_return_value
[       OK ] test_dma_map_return_value
[ RUN      ] test_handle_dma_unmap
[       OK ] test_handle_dma_unmap
[ RUN      ] test_dma_controller_add_region_no_fd
[       OK ] test_dma_controller_add_region_no_fd
[ RUN      ] test_dma_controller_add_region_fd_deduplication
[       OK ] test_dma_controller_add_region_fd_deduplication
[ RUN      ] test_dma_controller_add_region_twice
[       OK ] test_dma_controller_add_region_twice
[ RUN      ] test_dma_controller_remove_region_mapped
[       OK ] test_dma_controller_remove_region_mapped
[ RUN      ] test_dma_controller_remove_region_unmapped
[       OK ] test_dma_controller_remove_region_unmapped
[ RUN      ] test_dma_addr_to_sgl
[       OK ] test_dma_addr_to_sgl
[ RUN      ] test_vfu_setup_device_dma
[       OK ] test_vfu_setup_device_dma
[ RUN      ] test_device_is_stopped_and_copying
[       OK ] test_device_is_stopped_and_copying
[ RUN      ] test_cmd_allowed_when_stopped_and_copying
[       OK ] test_cmd_allowed_when_stopped_and_copying
[ RUN      ] test_should_exec_command
[       OK ] test_should_exec_command
[==========] 14 test(s) run.
[  PASSED  ] 14 test(s).
```

---

### cmocka 2.0.0 (Void Linux)

```
$ meson setup --reconfigure build
The Meson build system
Version: 1.9.1
Source dir: /home/jdeokkim/Workspace/libvfio-user
Build dir: /home/jdeokkim/Workspace/libvfio-user/build
Build type: native build
Project name: libvfio-user
Project version: 0.0.1
C compiler for the host machine: cc (gcc 14.2.1 "cc (GCC) 14.2.1 20250405")
C linker for the host machine: cc ld.bfd 2.44
Host machine cpu family: x86_64
Host machine cpu: x86_64
Run-time dependency threads found: YES
Library dl found: YES
Found pkg-config: YES (/usr/sbin/pkg-config) 0.29.2
Run-time dependency json-c found: YES 0.18

Run-time dependency cmocka found: YES 2.0.0

Program pytest-3 found: NO
Program flake8 found: NO
Program misspell-fixer found: NO
Program restructuredtext-lint found: NO
Program valgrind found: YES (/usr/sbin/valgrind)
Compiler for C supports arguments -Wno-missing-field-initializers: YES 
Compiler for C supports arguments -Wmissing-declarations: YES 
Compiler for C supports arguments -Wwrite-strings: YES 
Check usable header "linux/kcmp.h" : YES 
test/meson.build:20: WARNING: Project targets '>= 0.53.0' but uses feature introduced in '0.57.0': exclude_suites arg in add_test_setup.
Program test-lspci.sh found: YES (/home/jdeokkim/Workspace/libvfio-user/test/test-lspci.sh)
Program test-linkage.sh found: YES (/home/jdeokkim/Workspace/libvfio-user/test/test-linkage.sh)
test/py/meson.build:16: WARNING: Project targets '>= 0.53.0' but uses feature introduced in '0.57.0': exclude_suites arg in add_test_setup.
Build targets in project: 10
WARNING: Project specifies a minimum meson_version '>= 0.53.0' but uses features which were added in newer versions:
 * 0.57.0: {'exclude_suites arg in add_test_setup'}

Found ninja-1.13.2 at /usr/sbin/ninja
```

```
$ ninja -C build
ninja: Entering directory `build'
[48/48] Linking target test/unit_tests
```

```
$ ./build/test/unit_tests
./build/test/unit_tests
[==========] tests: Running 14 test(s).
[ RUN      ] test_dma_map_mappable_without_fd
[       OK ] test_dma_map_mappable_without_fd
[ RUN      ] test_dma_map_without_fd
[       OK ] test_dma_map_without_fd
[ RUN      ] test_dma_map_return_value
[       OK ] test_dma_map_return_value
[ RUN      ] test_handle_dma_unmap
[       OK ] test_handle_dma_unmap
[ RUN      ] test_dma_controller_add_region_no_fd
[       OK ] test_dma_controller_add_region_no_fd
[ RUN      ] test_dma_controller_add_region_fd_deduplication
[       OK ] test_dma_controller_add_region_fd_deduplication
[ RUN      ] test_dma_controller_add_region_twice
[       OK ] test_dma_controller_add_region_twice
[ RUN      ] test_dma_controller_remove_region_mapped
[       OK ] test_dma_controller_remove_region_mapped
[ RUN      ] test_dma_controller_remove_region_unmapped
[       OK ] test_dma_controller_remove_region_unmapped
[ RUN      ] test_dma_addr_to_sgl
[       OK ] test_dma_addr_to_sgl
[ RUN      ] test_vfu_setup_device_dma
[       OK ] test_vfu_setup_device_dma
[ RUN      ] test_device_is_stopped_and_copying
[       OK ] test_device_is_stopped_and_copying
[ RUN      ] test_cmd_allowed_when_stopped_and_copying
[       OK ] test_cmd_allowed_when_stopped_and_copying
[ RUN      ] test_should_exec_command
[       OK ] test_should_exec_command
[==========] tests: 14 test(s) run.
[  PASSED  ] 14 test(s).
```