### PR TITLE
always return ENOTCONN on connection reset

### DIFF
--- a/lib/libvfio-user.c
+++ b/lib/libvfio-user.c
@@ -1416,7 +1416,6 @@ get_request_header(vfu_ctx_t *vfu_ctx, vfu_msg_t **msgp)
                 if (errno != EBUSY) {
                     vfu_log(vfu_ctx, LOG_WARNING, "failed to reset context: %m");
                 }
-                return ret;
             }
             return ERROR_INT(ENOTCONN);
         default:


### PR DESCRIPTION
When a connection reset (ENOMSG/ECONNRESET) triggers vfu_reset_ctx(), the early "return ret" would return the reset error instead of ENOTCONN, hiding the connection loss from the caller.