### PR TITLE
refs #863 Fix mocks.c build error

### DIFF
--- a/test/mocks.c
+++ b/test/mocks.c
@@ -124,7 +124,7 @@ dma_controller_add_region(dma_controller_t *dma, void *dma_addr, uint64_t size,
     check_expected_ptr(dma);
     check_expected_ptr(dma_addr);
     check_expected_uint(size);
-    check_expected_int(fd);
+    check_expected_ptr(fd);
     check_expected_int(offset);
     check_expected_uint(prot);
     check_expected_int(access_mode);


### PR DESCRIPTION
#842 introduced a build error. This commit fixes that error.

I am in a Yocto 6.0 build environment with the following package versions:
gcc 15.2.0
cmake 4.3.1
cmocka 2.0.2
meson 1.10.2
ninja 1.13.2
json-c 0.18

Cmocka does not like the change from 'int fd' to 'int *fd'

`| x86_64-pokysdk-linux-gcc -march=x86-64 --sysroot=/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/recipe-sysroot -Itest/unit_tests.p -Itest -I../sources/libvfio-user-0.0.1/test -Iinclude -I../sources/libvfio-user-0.0.1/include -Ilib -I../sources/libvfio-user-0.0.1/lib -I/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/recipe-sysroot/usr/local/oe-sdk-hardcoded-buildpath/sysroots/x86_64-pokysdk-linux/usr/include/json-c -fdiagnostics-color=always -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -Wextra -std=gnu99 -O2 -fcanon-prefix-map -ffile-prefix-map=/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/sources/libvfio-user-0.0.1=/usr/src/debug/nativesdk-libvfio-user/0.0.1 -ffile-prefix-map=/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/build=/usr/src/debug/nativesdk-libvfio-user/0.0.1 -ffile-prefix-map=/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/recipe-sysroot= -ffile-prefix-map=/opt/workspace/demo/yocto/build/target/work/x86_64-nativesdk-pokysdk-linux/nativesdk-libvfio-user/0.0.1/recipe-sysroot-native= -pipe -DUNIT_TEST -DWITH_TRAN_PIPE -D_GNU_SOURCE -Wno-missing-field-initializers -Wmissing-declarations -Wwrite-strings -DHAVE_LINUX_KCMP_H -MD -MQ test/unit_tests.p/mocks.c.o -MF test/unit_tests.p/mocks.c.o.d -o test/unit_tests.p/mocks.c.o -c ../sources/libvfio-user-0.0.1/test/mocks.c | ../sources/libvfio-user-0.0.1/test/mocks.c: In function 'dma_controller_add_region': | ../sources/libvfio-user-0.0.1/test/mocks.c:127:5: error: initialization of 'long int' from 'int *' makes integer from pointer without a cast [-Wint-conversion] |   127 |     check_expected_int(fd); |       |     ^~~~~~~~~~~~~~~~~~ | ../sources/libvfio-user-0.0.1/test/mocks.c:127:5: note: (near initialization for '(anonymous).int_val') `

