### PR TITLE
CI: replace Alpine container with Debian-based for misspell-fixer

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -80,6 +80,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: install misspell-fixer
         run: |
+          apt-get update
           apt-get install -y git
           git clone https://github.com/vlajos/misspell-fixer.git /misspell-fixer
       - name: run misspell-fixer

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -79,6 +79,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: install misspell-fixer
-        run: git clone https://github.com/vlajos/misspell-fixer.git /misspell-fixer
+        run: |
+          apt-get install -y git
+          git clone https://github.com/vlajos/misspell-fixer.git /misspell-fixer
       - name: run misspell-fixer
         run: /misspell-fixer/misspell-fixer -sv .

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -75,8 +75,10 @@ jobs:
           make pre-push
   spelling:
     runs-on: ubuntu-latest
-    container: vlajos/misspell-fixer
+    container: debian:13
     steps:
       - uses: actions/checkout@v4
+      - name: install misspell-fixer
+        run: git clone https://github.com/vlajos/misspell-fixer.git /misspell-fixer
       - name: run misspell-fixer
         run: /misspell-fixer/misspell-fixer -sv .


### PR DESCRIPTION
Node 20 is deprecated and replaced by Node 24, however the vlajos/misspell-fixer Alpine 3.15 container (from 2021) is incompatible with Node 24 due to missing glibc symbols:

    Error relocating /__e/node24_alpine/bin/node: pthread_getname_np: symbol not found

Replace it with a Debian 13 base image and install misspell-fixer directly.

Signed-off-by: <thanos.makatos@nutanix.com>

fixes: #868