### PR TITLE
samples/gpio: return bytes written from migration write_data

### DIFF
--- a/samples/gpio-pci-idio-16.c
+++ b/samples/gpio-pci-idio-16.c
@@ -141,7 +141,7 @@ migration_write_data(UNUSED vfu_ctx_t *vfu_ctx, void *buf, uint64_t size)
 {
     assert(size == sizeof(pin));
     memcpy(&pin, buf, sizeof(pin));
-    return 0;
+    return size;
 }
 
 static void


### PR DESCRIPTION
The migration write_data callback must return the number of bytes written; returning 0 makes the server reject the transfer as a partial write. Return the requested size like read_data does.